### PR TITLE
WIP - feat: implement slash command support 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@ai-sdk/openai": "^1.1.9",
         "@floating-ui/react": "^0.27.6",
+        "@nozbe/microfuzz": "^1.0.0",
         "@radix-ui/react-slot": "^1.1.0",
         "date-fns": "^4.1.0",
         "katex": "^0.16.11",
@@ -3883,6 +3884,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@nozbe/microfuzz": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@nozbe/microfuzz/-/microfuzz-1.0.0.tgz",
+      "integrity": "sha512-XKIg/guk+s1tkPTkHch9hfGOWgsKojT7BqSQddXTppOfVr3SWQhhTCqbgQaPTbppf9gc2kFeG0gpBZZ612UXHA==",
+      "license": "MIT"
     },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "@ai-sdk/openai": "^1.1.9",
     "@floating-ui/react": "^0.27.6",
+    "@nozbe/microfuzz": "^1.0.0",
     "@radix-ui/react-slot": "^1.1.0",
     "date-fns": "^4.1.0",
     "katex": "^0.16.11",

--- a/src/ChatInput/ChatInput.tsx
+++ b/src/ChatInput/ChatInput.tsx
@@ -14,6 +14,10 @@ import SendIcon from '@/assets/send.svg?react';
 import StopIcon from '@/assets/stop.svg?react';
 import { ChatContext } from '@/ChatContext';
 import { FileInput } from './FileInput';
+import { SlashCommand } from './types';
+import { useSlashCommands } from './hooks/useSlashCommands';
+import { CommandDropdown } from './CommandDropdown';
+import { CommandIndicator } from './CommandIndicator';
 
 interface ChatInputProps {
   /**
@@ -45,6 +49,26 @@ interface ChatInputProps {
    * Icon to show for attach.
    */
   attachIcon?: ReactElement;
+
+  /**
+   * Slash commands available in the input.
+   */
+  commands?: SlashCommand[];
+
+  /**
+   * Callback when a command is selected.
+   */
+  onCommandSelect?: (command: SlashCommand) => void;
+
+  /**
+   * Custom filter function for commands.
+   */
+  commandFilter?: (command: SlashCommand, query: string) => boolean;
+
+  /**
+   * Maximum number of commands to show.
+   */
+  maxCommandsVisible?: number;
 }
 
 export interface ChatInputRef {
@@ -54,95 +78,179 @@ export interface ChatInputRef {
   focus: () => void;
 }
 
-export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(({
-  allowedFiles,
-  placeholder,
-  defaultValue,
-  sendIcon = <SendIcon />,
-  stopIcon = <StopIcon />,
-  attachIcon
-}, ref) => {
-  const { theme, isLoading, disabled, sendMessage, stopMessage, fileUpload, activeSessionId } =
-    useContext(ChatContext);
-  const [message, setMessage] = useState<string>('');
-  const inputRef = useRef<HTMLTextAreaElement | null>(null);
+export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
+  (
+    {
+      allowedFiles,
+      placeholder,
+      defaultValue,
+      sendIcon = <SendIcon />,
+      stopIcon = <StopIcon />,
+      attachIcon,
+      commands = [],
+      onCommandSelect,
+      commandFilter,
+      maxCommandsVisible
+    },
+    ref
+  ) => {
+    const {
+      theme,
+      isLoading,
+      disabled,
+      sendMessage,
+      stopMessage,
+      fileUpload,
+      activeSessionId
+    } = useContext(ChatContext);
+    const [message, setMessage] = useState<string>('');
+    const inputRef = useRef<HTMLTextAreaElement | null>(null);
 
-  useEffect(() => {
-    if(inputRef.current) {
-      inputRef.current.focus();
-    }
-  }, [activeSessionId, inputRef]);
+    const {
+      showDropdown,
+      filteredCommands,
+      selectedIndex,
+      handleKeyDown: handleSlashKeyDown,
+      handleInputChange: handleSlashInputChange,
+      selectCommand,
+      handleBlur,
+      lastSelectedCommand,
+      clearLastCommand
+    } = useSlashCommands({
+      commands,
+      onCommandSelect,
+      commandFilter,
+      maxCommandsVisible,
+      inputRef,
+      setMessage,
+      message
+    });
 
-  useImperativeHandle(ref, () => ({
-    focus: () => {
-      inputRef.current?.focus();
-    }
-  }));
+    useEffect(() => {
+      if (inputRef.current) {
+        inputRef.current.focus();
+      }
+    }, [activeSessionId, inputRef]);
 
-  const handleSendMessage = () => {
-    if (message.trim()) {
-      sendMessage?.(message);
-      setMessage('');
-    }
-  };
+    useImperativeHandle(ref, () => ({
+      focus: () => {
+        inputRef.current?.focus();
+      }
+    }));
 
-  const handleKeyPress = (e: KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault();
-      handleSendMessage();
-    }
-  };
+    const handleSendMessage = () => {
+      if (message.trim()) {
+        sendMessage?.(message);
+        setMessage('');
+      }
+    };
 
-  const handleFileUpload = (event: ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-    if (file && fileUpload) {
-      fileUpload(file);
-    }
-  };
+    const handleKeyPress = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      if (showDropdown) {
+        if (
+          e.key === 'Enter' ||
+          e.key === 'Tab' ||
+          e.key === 'Escape' ||
+          e.key === 'ArrowUp' ||
+          e.key === 'ArrowDown'
+        ) {
+          handleSlashKeyDown(e);
+          // Don't process further if it's a slash command key
+          if (e.defaultPrevented) {
+            return;
+          }
+        }
+      }
 
-  return (
-    <div className={cn(theme.input.base)}>
-      <Textarea
-        ref={inputRef}
-        containerClassName={cn(theme.input.input)}
-        minRows={1}
-        autoFocus
-        value={message}
-        defaultValue={defaultValue}
-        onKeyPress={handleKeyPress}
-        placeholder={placeholder}
-        disabled={isLoading || disabled}
-        onChange={e => setMessage(e.target.value)}
-      />
-      <div className={cn(theme.input.actions.base)}>
-        {allowedFiles?.length > 0 && (
-          <FileInput
-            allowedFiles={allowedFiles}
-            onFileUpload={handleFileUpload}
-            isLoading={isLoading}
-            disabled={disabled}
-            attachIcon={attachIcon}
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        handleSendMessage();
+      }
+    };
+
+    const handleInputChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+      setMessage(e.target.value);
+      if (commands.length > 0) {
+        handleSlashInputChange(e);
+      }
+      // Clear command indicator when user types after command selection
+      if (lastSelectedCommand) {
+        clearLastCommand();
+      }
+    };
+
+    const handleFileUpload = (event: ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      if (file && fileUpload) {
+        fileUpload(file);
+      }
+    };
+
+    return (
+      <div className={cn(theme.input.base, 'relative overflow-visible')}>
+        <CommandIndicator
+          command={lastSelectedCommand}
+          onDismiss={clearLastCommand}
+        />
+        {showDropdown && (
+          <CommandDropdown
+            commands={filteredCommands}
+            selectedIndex={selectedIndex}
+            onSelect={selectCommand}
           />
         )}
-        {isLoading && (
-          <Button
-            title="Stop"
-            className={cn(theme.input.actions.stop)}
-            onClick={stopMessage}
-            disabled={disabled}
-          >
-            {stopIcon}
-          </Button>
-        )}
-        <Button
-          title="Send"
-          className={cn(theme.input.actions.send)}
-          onClick={handleSendMessage}
+        <Textarea
+          ref={inputRef}
+          containerClassName={cn(theme.input.input)}
+          minRows={1}
+          autoFocus
+          value={message}
+          defaultValue={defaultValue}
+          onKeyDown={handleKeyPress}
+          placeholder={placeholder}
           disabled={isLoading || disabled}
-        >
-          {sendIcon}
-        </Button>
+          onChange={handleInputChange}
+          onBlur={handleBlur}
+          role="combobox"
+          aria-autocomplete="list"
+          aria-expanded={showDropdown}
+          aria-controls={showDropdown ? 'command-listbox' : undefined}
+          aria-activedescendant={
+            showDropdown && selectedIndex >= 0
+              ? `command-${selectedIndex}`
+              : undefined
+          }
+        />
+        <div className={cn(theme.input.actions.base)}>
+          {allowedFiles?.length > 0 && (
+            <FileInput
+              allowedFiles={allowedFiles}
+              onFileUpload={handleFileUpload}
+              isLoading={isLoading}
+              disabled={disabled}
+              attachIcon={attachIcon}
+            />
+          )}
+          {isLoading && (
+            <Button
+              title="Stop"
+              className={cn(theme.input.actions.stop)}
+              onClick={stopMessage}
+              disabled={disabled}
+            >
+              {stopIcon}
+            </Button>
+          )}
+          <Button
+            title="Send"
+            className={cn(theme.input.actions.send)}
+            onClick={handleSendMessage}
+            disabled={isLoading || disabled}
+          >
+            {sendIcon}
+          </Button>
+        </div>
       </div>
-    </div>
-  );
-});
+    );
+  }
+);

--- a/src/ChatInput/CommandDropdown.tsx
+++ b/src/ChatInput/CommandDropdown.tsx
@@ -1,0 +1,59 @@
+import { FC, useContext } from 'react';
+import { cn } from 'reablocks';
+import { CommandDropdownProps } from './types';
+import { CommandItem } from './CommandItem';
+import { ChatContext } from '@/ChatContext';
+
+export const CommandDropdown: FC<CommandDropdownProps> = ({
+  commands,
+  selectedIndex,
+  onSelect
+}) => {
+  const { theme } = useContext(ChatContext);
+
+  if (commands.length === 0) {
+    return (
+      <div
+        className={cn(theme.input.commands?.dropdown)}
+        role="listbox"
+        id="command-listbox"
+      >
+        <div className={cn(theme.input.commands?.list)}>
+          <div className={cn(theme.input.commands?.empty)}>
+            No commands found
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn(theme.input.commands?.dropdown)}
+      role="listbox"
+      id="command-listbox"
+      aria-label="Slash commands"
+    >
+      <div className={cn(theme.input.commands?.list)}>
+        {commands.map((command, index) => (
+          <CommandItem
+            key={command.id}
+            command={command}
+            isSelected={index === selectedIndex}
+            onSelect={onSelect}
+            index={index}
+          />
+        ))}
+      </div>
+      <div
+        className="sr-only"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        {commands.length} {commands.length === 1 ? 'command' : 'commands'}{' '}
+        available
+      </div>
+    </div>
+  );
+};

--- a/src/ChatInput/CommandIndicator.tsx
+++ b/src/ChatInput/CommandIndicator.tsx
@@ -1,0 +1,69 @@
+import { FC, useContext, useEffect, useState } from 'react';
+import { cn } from 'reablocks';
+import { motion, AnimatePresence } from 'motion/react';
+import { SlashCommand } from './types';
+import { ChatContext } from '@/ChatContext';
+
+export interface CommandIndicatorProps {
+  command: SlashCommand | null;
+  onDismiss: () => void;
+  autoHideDelay?: number;
+}
+
+export const CommandIndicator: FC<CommandIndicatorProps> = ({
+  command,
+  onDismiss,
+  autoHideDelay = 3000
+}) => {
+  const { theme } = useContext(ChatContext);
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    if (command) {
+      setIsVisible(true);
+      const timer = setTimeout(() => {
+        setIsVisible(false);
+        setTimeout(onDismiss, 200); // Wait for animation to complete
+      }, autoHideDelay);
+
+      return () => clearTimeout(timer);
+    } else {
+      setIsVisible(false);
+    }
+  }, [command, autoHideDelay, onDismiss]);
+
+  return (
+    <AnimatePresence>
+      {isVisible && command && (
+        <motion.div
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -10 }}
+          transition={{ duration: 0.2 }}
+          className={cn(theme.input.commands?.indicator)}
+        >
+          <div className="flex items-center gap-2">
+            {'icon' in command && command.icon && (
+              <span className={cn(theme.input.commands?.indicatorIcon)}>
+                {command.icon}
+              </span>
+            )}
+            <span className={cn(theme.input.commands?.indicatorLabel)}>
+              Command: /{command.label}
+            </span>
+            <button
+              onClick={() => {
+                setIsVisible(false);
+                setTimeout(onDismiss, 200);
+              }}
+              className={cn(theme.input.commands?.indicatorClose)}
+              aria-label="Dismiss"
+            >
+              ×
+            </button>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+};

--- a/src/ChatInput/CommandItem.tsx
+++ b/src/ChatInput/CommandItem.tsx
@@ -1,0 +1,43 @@
+import { FC, useContext } from 'react';
+import { cn } from 'reablocks';
+import { CommandItemProps } from './types';
+import { ChatContext } from '@/ChatContext';
+
+export const CommandItem: FC<CommandItemProps> = ({
+  command,
+  isSelected,
+  onSelect,
+  index
+}) => {
+  const { theme } = useContext(ChatContext);
+
+  const handleClick = () => {
+    onSelect(command);
+  };
+
+  return (
+    <div
+      role="option"
+      id={`command-${index}`}
+      aria-selected={isSelected}
+      className={cn(
+        theme.input.commands?.item,
+        isSelected && theme.input.commands?.itemSelected
+      )}
+      onClick={handleClick}
+      onMouseDown={e => e.preventDefault()}
+    >
+      {'icon' in command && command.icon && (
+        <span className={cn(theme.input.commands?.icon)}>{command.icon}</span>
+      )}
+      <div className="flex-1">
+        <div className={cn(theme.input.commands?.label)}>/{command.label}</div>
+        {'description' in command && command.description && (
+          <div className={cn(theme.input.commands?.description)}>
+            {command.description}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/ChatInput/hooks/useSlashCommands.ts
+++ b/src/ChatInput/hooks/useSlashCommands.ts
@@ -1,0 +1,202 @@
+import {
+  useState,
+  useCallback,
+  KeyboardEvent,
+  ChangeEvent,
+  useEffect
+} from 'react';
+import { useFuzzySearchList } from '@nozbe/microfuzz/react';
+import { SlashCommand, UseSlashCommandsOptions } from '@/ChatInput/types';
+
+export function useSlashCommands({
+  commands,
+  onCommandSelect,
+  commandFilter,
+  maxCommandsVisible = 10,
+  inputRef,
+  setMessage,
+  message
+}: UseSlashCommandsOptions) {
+  const [showDropdown, setShowDropdown] = useState(false);
+  const [commandQuery, setCommandQuery] = useState('');
+  const [selectedIndex, setSelectedIndex] = useState(-1);
+  const [slashPosition, setSlashPosition] = useState(-1);
+  const [lastSelectedCommand, setLastSelectedCommand] =
+    useState<SlashCommand | null>(null);
+
+  const visibleCommands = commands.filter(cmd => {
+    const richCmd = cmd as any;
+    if (richCmd.visible === undefined) return true;
+    if (typeof richCmd.visible === 'boolean') return richCmd.visible;
+    if (typeof richCmd.visible === 'function') return richCmd.visible({});
+    return true;
+  });
+
+  const fuzzyResults = useFuzzySearchList({
+    list: visibleCommands,
+    queryText: commandQuery,
+    getText: (item: SlashCommand) => {
+      const texts = [item.label];
+      if ('description' in item && item.description) {
+        texts.push(item.description);
+      }
+      return texts;
+    },
+    mapResultItem: ({ item, score, matches }) => ({ item, score, matches })
+  });
+
+  const filteredCommands = fuzzyResults
+    .filter(result => {
+      if (commandFilter) {
+        return commandFilter(result.item, commandQuery);
+      }
+      return true;
+    })
+    .slice(0, maxCommandsVisible)
+    .map(result => result.item);
+
+  const handleInputChange = useCallback(
+    (e: ChangeEvent<HTMLTextAreaElement>) => {
+      const value = e.target.value;
+      const cursorPos = e.target.selectionStart || 0;
+
+      const textBeforeCursor = value.slice(0, cursorPos);
+      const slashMatch = textBeforeCursor.match(/(?:^|\s)\/(\S*)$/);
+
+      if (slashMatch) {
+        const position =
+          slashMatch.index! + (slashMatch[0].startsWith(' ') ? 1 : 0);
+        setSlashPosition(position);
+        setCommandQuery(slashMatch[1]);
+        setShowDropdown(true);
+        setSelectedIndex(0); // Auto-select first item
+      } else {
+        setShowDropdown(false);
+        setCommandQuery('');
+        setSelectedIndex(-1);
+      }
+    },
+    []
+  );
+
+  const selectCommand = useCallback(
+    (command: SlashCommand) => {
+      // Use the message state instead of relying on the ref
+      const value = message;
+
+      const beforeSlash = value.substring(0, slashPosition);
+      const afterCommand = value.substring(
+        slashPosition + commandQuery.length + 1
+      );
+
+      const newValue = beforeSlash + command.value + afterCommand;
+
+      // Always update the message state (doesn't require ref)
+      setMessage(newValue);
+
+      // Set cursor position only if ref is available (progressive enhancement)
+      if (inputRef.current) {
+        setTimeout(() => {
+          if (inputRef.current) {
+            const newCursorPos = slashPosition + command.value.length;
+            inputRef.current.setSelectionRange(newCursorPos, newCursorPos);
+            inputRef.current.focus();
+          }
+        }, 0);
+      }
+
+      if ('action' in command && command.action) {
+        command.action();
+      }
+
+      onCommandSelect?.(command);
+
+      // Set the last selected command for indicator
+      setLastSelectedCommand(command);
+
+      setShowDropdown(false);
+      setCommandQuery('');
+      setSelectedIndex(-1);
+      setSlashPosition(-1);
+    },
+    [
+      slashPosition,
+      commandQuery,
+      inputRef,
+      onCommandSelect,
+      setMessage,
+      message
+    ]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      if (!showDropdown || filteredCommands.length === 0) return;
+
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          setSelectedIndex(prev => {
+            const next = prev + 1;
+            return next >= filteredCommands.length ? 0 : next;
+          });
+          break;
+
+        case 'ArrowUp':
+          e.preventDefault();
+          setSelectedIndex(prev => {
+            const next = prev - 1;
+            return next < 0 ? filteredCommands.length - 1 : next;
+          });
+          break;
+
+        case 'Enter':
+        case 'Tab':
+          e.preventDefault();
+          e.stopPropagation();
+          // Use selected index if available, otherwise select first item
+          const indexToSelect = selectedIndex >= 0 ? selectedIndex : 0;
+          if (indexToSelect < filteredCommands.length) {
+            selectCommand(filteredCommands[indexToSelect]);
+          }
+          break;
+
+        case 'Escape':
+          e.preventDefault();
+          setShowDropdown(false);
+          setSelectedIndex(-1);
+          break;
+      }
+    },
+    [showDropdown, filteredCommands, selectedIndex, selectCommand]
+  );
+
+  useEffect(() => {
+    if (selectedIndex >= filteredCommands.length) {
+      setSelectedIndex(Math.max(0, filteredCommands.length - 1));
+    }
+  }, [filteredCommands.length, selectedIndex]);
+
+  const handleBlur = useCallback(() => {
+    setTimeout(() => {
+      setShowDropdown(false);
+      setSelectedIndex(-1);
+    }, 200);
+  }, []);
+
+  const clearLastCommand = useCallback(() => {
+    setLastSelectedCommand(null);
+  }, []);
+
+  return {
+    showDropdown,
+    filteredCommands,
+    selectedIndex,
+    handleKeyDown,
+    handleInputChange,
+    selectCommand,
+    handleBlur,
+    lastSelectedCommand,
+    clearLastCommand
+  };
+}

--- a/src/ChatInput/index.ts
+++ b/src/ChatInput/index.ts
@@ -1,2 +1,6 @@
 export * from './ChatInput';
 export * from './FileInput';
+export * from './types';
+export * from './CommandDropdown';
+export * from './CommandItem';
+export * from './CommandIndicator';

--- a/src/ChatInput/types.ts
+++ b/src/ChatInput/types.ts
@@ -1,0 +1,53 @@
+import { ReactElement, RefObject } from 'react';
+
+export interface SimpleCommand {
+  id: string;
+  label: string;
+  value: string;
+}
+
+export interface RichCommand extends SimpleCommand {
+  description?: string;
+  icon?: ReactElement;
+  action?: () => void;
+  template?: string;
+  visible?: boolean | ((context: any) => boolean);
+}
+
+export type SlashCommand = SimpleCommand | RichCommand;
+
+export interface ChatInputProps {
+  defaultValue?: string;
+  allowedFiles?: string[];
+  placeholder?: string;
+  sendIcon?: ReactElement;
+  stopIcon?: ReactElement;
+  attachIcon?: ReactElement;
+  commands?: SlashCommand[];
+  onCommandSelect?: (command: SlashCommand) => void;
+  commandFilter?: (command: SlashCommand, query: string) => boolean;
+  maxCommandsVisible?: number;
+}
+
+export interface UseSlashCommandsOptions {
+  commands: SlashCommand[];
+  onCommandSelect?: (command: SlashCommand) => void;
+  commandFilter?: (command: SlashCommand, query: string) => boolean;
+  maxCommandsVisible?: number;
+  inputRef: RefObject<HTMLTextAreaElement>;
+  setMessage: (message: string) => void;
+  message: string;
+}
+
+export interface CommandDropdownProps {
+  commands: SlashCommand[];
+  selectedIndex: number;
+  onSelect: (command: SlashCommand) => void;
+}
+
+export interface CommandItemProps {
+  command: SlashCommand;
+  isSelected: boolean;
+  onSelect: (command: SlashCommand) => void;
+  index: number;
+}

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -82,6 +82,20 @@ export interface ChatTheme {
       send: string;
       stop: string;
     };
+    commands?: {
+      dropdown: string;
+      list: string;
+      item: string;
+      itemSelected: string;
+      label: string;
+      description: string;
+      icon: string;
+      empty: string;
+      indicator: string;
+      indicatorLabel: string;
+      indicatorIcon: string;
+      indicatorClose: string;
+    };
   };
 }
 
@@ -208,6 +222,37 @@ export const chatTheme: ChatTheme = {
         'dark:text-white light:text-gray-500 dark:bg-gray-800 dark:hover:bg-gray-700'
       ].join(' '),
       stop: 'px-2 py-2 bg-red-500 text-white rounded-full hover:bg-red-700 '
+    },
+    commands: {
+      dropdown: [
+        'absolute z-50 w-full bottom-full mb-2 bg-white border border-gray-200 rounded-lg shadow-lg max-h-60 overflow-auto',
+        'dark:bg-gray-900 dark:border-gray-700'
+      ].join(' '),
+      list: 'py-1',
+      item: [
+        'px-3 py-2 hover:bg-gray-100 cursor-pointer flex items-center gap-2',
+        'dark:hover:bg-gray-800'
+      ].join(' '),
+      itemSelected: ['bg-blue-50', 'dark:bg-blue-950/40'].join(' '),
+      label: ['font-medium text-gray-900', 'dark:text-gray-100'].join(' '),
+      description: ['text-sm text-gray-600', 'dark:text-gray-400'].join(' '),
+      icon: ['w-4 h-4 text-gray-500', 'dark:text-gray-400'].join(' '),
+      empty: ['px-3 py-2 text-gray-500 text-center', 'dark:text-gray-400'].join(
+        ' '
+      ),
+      indicator: [
+        'absolute bottom-full mb-2 left-0 px-3 py-2 bg-blue-50 border border-blue-200 rounded-lg shadow-sm',
+        'dark:bg-blue-950/40 dark:border-blue-800'
+      ].join(' '),
+      indicatorLabel: [
+        'text-sm font-medium text-blue-700',
+        'dark:text-blue-300'
+      ].join(' '),
+      indicatorIcon: ['w-4 h-4 text-blue-600', 'dark:text-blue-400'].join(' '),
+      indicatorClose: [
+        'ml-2 text-lg leading-none text-blue-600 hover:text-blue-800 cursor-pointer',
+        'dark:text-blue-400 dark:hover:text-blue-200'
+      ].join(' ')
     }
   }
 };

--- a/stories/SlashCommands.stories.tsx
+++ b/stories/SlashCommands.stories.tsx
@@ -1,0 +1,336 @@
+import { useState } from 'react';
+import { Meta } from '@storybook/react';
+import {
+  Chat,
+  Session,
+  SessionsList,
+  SessionsGroup,
+  SessionListItem,
+  NewSessionButton,
+  SessionMessages,
+  SessionGroups,
+  ChatInput,
+  SessionMessagePanel,
+  SessionMessagesHeader,
+  SlashCommand
+} from '../src';
+import { subHours } from 'date-fns';
+import HelpIcon from './assets/menu.svg?react';
+import CodeIcon from './assets/placeholder.svg?react';
+
+export default {
+  title: 'Slash Commands',
+  component: Chat
+} as Meta;
+
+const BugIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
+    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+  </svg>
+);
+
+const ClearIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <line x1="18" y1="6" x2="6" y2="18"/>
+    <line x1="6" y1="6" x2="18" y2="18"/>
+  </svg>
+);
+
+export const SimpleCommands = () => {
+  const simpleCommands: SlashCommand[] = [
+    { id: '1', label: 'help', value: 'help' },
+    { id: '2', label: 'clear', value: 'clear' },
+    { id: '3', label: 'settings', value: 'settings' },
+    { id: '4', label: 'about', value: 'about' },
+    { id: '5', label: 'version', value: 'version' }
+  ];
+
+  const sessions: Session[] = [
+    {
+      id: '1',
+      title: 'Slash Commands Demo',
+      createdAt: subHours(new Date(), 1),
+      updatedAt: new Date(),
+      conversations: [
+        {
+          id: '1',
+          question: 'How do slash commands work?',
+          response: 'Type "/" to trigger the command menu. You can filter commands by typing after the slash.',
+          createdAt: new Date()
+        }
+      ]
+    }
+  ];
+
+  return (
+    <div
+      className="dark:bg-gray-950 bg-white"
+      style={{
+        position: 'absolute',
+        inset: 0,
+        padding: 20,
+        margin: 20,
+        borderRadius: 5
+      }}
+    >
+      <Chat
+        sessions={sessions}
+        activeSessionId="1"
+        onDeleteSession={() => alert('delete!')}
+      >
+        <SessionsList>
+          <NewSessionButton />
+          <SessionGroups />
+        </SessionsList>
+
+        <SessionMessagePanel>
+          <SessionMessagesHeader />
+          <SessionMessages />
+          <ChatInput 
+            commands={simpleCommands}
+            onCommandSelect={(cmd) => console.log('Selected command:', cmd)}
+            placeholder="Type / for commands"
+          />
+        </SessionMessagePanel>
+      </Chat>
+    </div>
+  );
+};
+
+export const RichCommands = () => {
+  const richCommands: SlashCommand[] = [
+    {
+      id: 'bug',
+      label: 'bug',
+      value: 'Bug Report:\nDescription:\nSteps to Reproduce:\n1. ',
+      description: 'Create a bug report',
+      icon: <BugIcon />
+    },
+    {
+      id: 'code',
+      label: 'code',
+      value: '```\n\n```',
+      description: 'Insert code block',
+      icon: <CodeIcon />
+    },
+    {
+      id: 'help',
+      label: 'help',
+      value: 'How can I help you today?',
+      description: 'Get help',
+      icon: <HelpIcon />
+    },
+    {
+      id: 'clear',
+      label: 'clear',
+      value: '/clear',
+      description: 'Clear the chat',
+      icon: <ClearIcon />,
+      action: () => alert('Clear action triggered!')
+    }
+  ];
+
+  const sessions: Session[] = [
+    {
+      id: '1',
+      title: 'Rich Commands Demo',
+      createdAt: subHours(new Date(), 1),
+      updatedAt: new Date(),
+      conversations: [
+        {
+          id: '1',
+          question: 'What are rich commands?',
+          response: 'Rich commands can include descriptions, icons, and custom actions. Try typing "/" to see them!',
+          createdAt: new Date()
+        }
+      ]
+    }
+  ];
+
+  return (
+    <div
+      className="dark:bg-gray-950 bg-white"
+      style={{
+        position: 'absolute',
+        inset: 0,
+        padding: 20,
+        margin: 20,
+        borderRadius: 5
+      }}
+    >
+      <Chat
+        sessions={sessions}
+        activeSessionId="1"
+        onDeleteSession={() => alert('delete!')}
+      >
+        <SessionsList>
+          <NewSessionButton />
+          <SessionGroups />
+        </SessionsList>
+
+        <SessionMessagePanel>
+          <SessionMessagesHeader />
+          <SessionMessages />
+          <ChatInput 
+            commands={richCommands}
+            onCommandSelect={(cmd) => console.log('Selected command:', cmd)}
+            placeholder="Type / for commands"
+          />
+        </SessionMessagePanel>
+      </Chat>
+    </div>
+  );
+};
+
+export const ConditionalCommands = () => {
+  const [isAdmin, setIsAdmin] = useState(false);
+
+  const conditionalCommands: SlashCommand[] = [
+    { id: '1', label: 'help', value: 'help', description: 'Get help' },
+    { id: '2', label: 'clear', value: 'clear', description: 'Clear the chat' },
+    { 
+      id: '3', 
+      label: 'admin', 
+      value: 'admin', 
+      description: 'Admin commands',
+      visible: isAdmin
+    },
+    {
+      id: '4',
+      label: 'debug',
+      value: 'debug',
+      description: 'Debug mode',
+      visible: () => isAdmin
+    }
+  ];
+
+  const sessions: Session[] = [
+    {
+      id: '1',
+      title: 'Conditional Commands',
+      createdAt: subHours(new Date(), 1),
+      updatedAt: new Date(),
+      conversations: [
+        {
+          id: '1',
+          question: 'How do conditional commands work?',
+          response: 'Commands can be shown or hidden based on conditions. Toggle admin mode above to see admin commands.',
+          createdAt: new Date()
+        }
+      ]
+    }
+  ];
+
+  return (
+    <div
+      className="dark:bg-gray-950 bg-white"
+      style={{
+        position: 'absolute',
+        inset: 0,
+        padding: 20,
+        margin: 20,
+        borderRadius: 5
+      }}
+    >
+      <div style={{ marginBottom: 10 }}>
+        <label>
+          <input
+            type="checkbox"
+            checked={isAdmin}
+            onChange={(e) => setIsAdmin(e.target.checked)}
+          />
+          {' '}Admin Mode
+        </label>
+      </div>
+      
+      <Chat
+        sessions={sessions}
+        activeSessionId="1"
+        onDeleteSession={() => alert('delete!')}
+      >
+        <SessionsList>
+          <NewSessionButton />
+          <SessionGroups />
+        </SessionsList>
+
+        <SessionMessagePanel>
+          <SessionMessagesHeader />
+          <SessionMessages />
+          <ChatInput 
+            commands={conditionalCommands}
+            onCommandSelect={(cmd) => console.log('Selected command:', cmd)}
+            placeholder="Type / for commands"
+          />
+        </SessionMessagePanel>
+      </Chat>
+    </div>
+  );
+};
+
+export const FilteredCommands = () => {
+  const manyCommands: SlashCommand[] = Array.from({ length: 20 }, (_, i) => ({
+    id: `cmd-${i}`,
+    label: `command${i}`,
+    value: `Command ${i} executed`,
+    description: `This is command number ${i}`
+  }));
+
+  const customFilter = (command: SlashCommand, query: string) => {
+    return command.label.includes(query) || 
+           ('description' in command && command.description && command.description.toLowerCase().includes(query.toLowerCase()));
+  };
+
+  const sessions: Session[] = [
+    {
+      id: '1',
+      title: 'Filtered Commands',
+      createdAt: subHours(new Date(), 1),
+      updatedAt: new Date(),
+      conversations: [
+        {
+          id: '1',
+          question: 'How does filtering work?',
+          response: 'Commands are filtered using fuzzy search. You can also provide a custom filter function.',
+          createdAt: new Date()
+        }
+      ]
+    }
+  ];
+
+  return (
+    <div
+      className="dark:bg-gray-950 bg-white"
+      style={{
+        position: 'absolute',
+        inset: 0,
+        padding: 20,
+        margin: 20,
+        borderRadius: 5
+      }}
+    >
+      <Chat
+        sessions={sessions}
+        activeSessionId="1"
+        onDeleteSession={() => alert('delete!')}
+      >
+        <SessionsList>
+          <NewSessionButton />
+          <SessionGroups />
+        </SessionsList>
+
+        <SessionMessagePanel>
+          <SessionMessagesHeader />
+          <SessionMessages />
+          <ChatInput 
+            commands={manyCommands}
+            commandFilter={customFilter}
+            maxCommandsVisible={5}
+            onCommandSelect={(cmd) => console.log('Selected command:', cmd)}
+            placeholder="Type / for commands (showing max 5)"
+          />
+        </SessionMessagePanel>
+      </Chat>
+    </div>
+  );
+};


### PR DESCRIPTION
# feat: Add slash command support with fuzzy search

## Description

This PR implements Slack-style slash commands for the ChatInput component, allowing users to trigger predefined commands by typing "/" which displays an inline dropdown with fuzzy search capabilities.

## Changes Made

- Add SlashCommand types and interfaces in ChatInput/types.ts
- Create useSlashCommands hook with fuzzy search and keyboard navigation
- Implement CommandDropdown, CommandItem, and CommandIndicator components
- Update ChatInput to integrate slash command functionality
- Fix selectCommand to handle null textarea ref gracefully using message state
- Add @nozbe/microfuzz dependency for fuzzy search functionality
- Include comprehensive Storybook stories for slash command features

The Enter key issue was resolved by using the message state as fallback when the textarea ref is null, ensuring commands work reliably.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, the ChatInput component does not support slash commands. Users cannot trigger predefined commands or templates by typing "/".

Issue Number: N/A

## What is the new behavior?

Users can now:
- Type "/" to trigger a command dropdown menu
- Search commands using fuzzy search as they type after "/"
- Navigate commands with arrow keys while maintaining focus in the input
- Select commands with Enter or Tab
- Close the dropdown with Escape
- See command descriptions and icons in rich command format
- Use conditional visibility for commands based on context

The implementation includes:
- Full keyboard navigation support
- ARIA attributes for accessibility
- Fuzzy search powered by @nozbe/microfuzz
- Support for both simple and rich command formats
- Command filtering and customization options
- Visual indicator when a command is selected

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

### Usage Example

```tsx
const commands = [
  { id: '1', label: 'help', value: 'How can I help you?' },
  { 
    id: '2', 
    label: 'bug', 
    value: 'Bug Report:\nDescription:\n', 
    description: 'Create a bug report',
    icon: <BugIcon />
  }
];

<ChatInput 
  commands={commands}
  onCommandSelect={(cmd) => console.log('Selected:', cmd)}
  maxCommandsVisible={5}
/>
```

### Testing

The implementation has been tested with:
- Multiple Storybook stories demonstrating various use cases
- Manual testing of keyboard navigation and selection
- Verification that commands work even when textarea ref is temporarily null

### Screenshots
<img width="1717" height="909" alt="Google Chrome 2025-08-21 20 36 07" src="https://github.com/user-attachments/assets/237bd052-7244-41fd-ac9b-b1668e2e0e09" />


<img width="1591" height="789" alt="Google Chrome 2025-08-21 20 36 13" src="https://github.com/user-attachments/assets/af927e5e-d8d0-49ba-8e6e-994c5f0f1dc6" />


![CleanShot 2025-08-21 at 19 37 01](https://github.com/user-attachments/assets/a8d08428-754c-4a7c-bef8-1c82d167c7e2)


The feature includes visual components for:
- Inline dropdown below the input area
- Highlighted selection during keyboard navigation
- Command icons and descriptions
- Selected command indicator