### PR TITLE
feat: add customizable input layout with slot props and reusable sub-components

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,12 +93,9 @@ importers:
         specifier: ^5.0.0
         version: 5.1.0
       zod:
-        specifier: ^3.25.0 || ^4.0.0
+        specifier: ^4.0.0
         version: 4.3.6
     devDependencies:
-      '@ai-sdk/openai':
-        specifier: ^1.1.9
-        version: 1.3.24(zod@4.3.6)
       '@storybook/addon-docs':
         specifier: ^8.2.6
         version: 8.6.15(@types/react@18.3.28)(storybook@8.6.15(prettier@3.8.1))
@@ -165,9 +162,6 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^1.4.0
         version: 1.6.1(vitest@1.6.1(@types/node@18.19.130)(jsdom@24.1.3)(lightningcss@1.30.2))
-      ai:
-        specifier: ^4.1.35
-        version: 4.3.19(react@18.3.1)(zod@4.3.6)
       autoprefixer:
         specifier: ^10.4.19
         version: 10.4.24(postcss@8.5.6)
@@ -201,9 +195,6 @@ importers:
       lint-staged:
         specifier: ^15.2.2
         version: 15.5.2
-      openai:
-        specifier: ^4.84.0
-        version: 4.104.0(ws@8.19.0)(zod@4.3.6)
       postcss:
         specifier: ^8.4.39
         version: 8.5.6
@@ -272,38 +263,6 @@ importers:
         version: 1.6.1(@types/node@18.19.130)(jsdom@24.1.3)(lightningcss@1.30.2)
 
 packages:
-
-  '@ai-sdk/openai@1.3.24':
-    resolution: {integrity: sha512-GYXnGJTHRTZc4gJMSmFRgEQudjqd4PUN0ZjQhPwOAYH1yOAvQoG/Ikqs+HyISRbLPCrhbZnPKCNHuRU4OfpW0Q==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.0.0
-
-  '@ai-sdk/provider-utils@2.2.8':
-    resolution: {integrity: sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.23.8
-
-  '@ai-sdk/provider@1.1.3':
-    resolution: {integrity: sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==}
-    engines: {node: '>=18'}
-
-  '@ai-sdk/react@1.2.12':
-    resolution: {integrity: sha512-jK1IZZ22evPZoQW3vlkZ7wvjYGYF+tRBKXtrcolduIkQ/m/sOAVcVeVDUDvh1T91xCnWCdUGCPZg2avZ90mv3g==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      react: ^18 || ^19 || ^19.0.0-rc
-      zod: ^3.23.8
-    peerDependenciesMeta:
-      zod:
-        optional: true
-
-  '@ai-sdk/ui-utils@1.2.11':
-    resolution: {integrity: sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.23.8
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -1095,10 +1054,6 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
-
-  '@opentelemetry/api@1.9.0':
-    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
-    engines: {node: '>=8.0.0'}
 
   '@parcel/watcher-android-arm64@2.5.6':
     resolution: {integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==}
@@ -1893,9 +1848,6 @@ packages:
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
-  '@types/diff-match-patch@1.0.36':
-    resolution: {integrity: sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==}
-
   '@types/doctrine@0.0.9':
     resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
 
@@ -1934,9 +1886,6 @@ packages:
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
-
-  '@types/node-fetch@2.6.13':
-    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
 
   '@types/node@18.19.130':
     resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
@@ -2119,10 +2068,6 @@ packages:
   '@vue/shared@3.5.28':
     resolution: {integrity: sha512-cfWa1fCGBxrvaHRhvV3Is0MgmrbSCxYTXCSCau2I0a1Xw1N1pHAvkWCiXPRAqjvToILvguNyEwjevUqAuBQWvQ==}
 
-  abort-controller@3.0.0:
-    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
-    engines: {node: '>=6.5'}
-
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -2140,20 +2085,6 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
-
-  agentkeepalive@4.6.0:
-    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
-    engines: {node: '>= 8.0.0'}
-
-  ai@4.3.19:
-    resolution: {integrity: sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      react: ^18 || ^19 || ^19.0.0-rc
-      zod: ^3.23.8
-    peerDependenciesMeta:
-      react:
-        optional: true
 
   ajv-draft-04@1.0.0:
     resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
@@ -2661,9 +2592,6 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
-  diff-match-patch@1.0.5:
-    resolution: {integrity: sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==}
-
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -2877,10 +2805,6 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
-  event-target-shim@5.0.1:
-    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
-    engines: {node: '>=6'}
-
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
@@ -2967,9 +2891,6 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  form-data-encoder@1.7.2:
-    resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
-
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
@@ -2977,10 +2898,6 @@ packages:
   format@0.2.2:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
     engines: {node: '>=0.4.x'}
-
-  formdata-node@4.4.1:
-    resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
-    engines: {node: '>= 12.20'}
 
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
@@ -3202,9 +3119,6 @@ packages:
   human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
-
-  humanize-ms@1.2.1:
-    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
@@ -3493,20 +3407,12 @@ packages:
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
-  json-schema@0.4.0:
-    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
-
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
-    hasBin: true
-
-  jsondiffpatch@0.6.0:
-    resolution: {integrity: sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==}
-    engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
   jsonfile@6.2.0:
@@ -3944,20 +3850,6 @@ packages:
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
-  node-domexception@1.0.0:
-    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
-    engines: {node: '>=10.5.0'}
-    deprecated: Use your platform's native DOMException instead
-
-  node-fetch@2.7.0:
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
-
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
@@ -4018,18 +3910,6 @@ packages:
   open@8.4.2:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
-
-  openai@4.104.0:
-    resolution: {integrity: sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==}
-    hasBin: true
-    peerDependencies:
-      ws: ^8.18.0
-      zod: ^3.23.8
-    peerDependenciesMeta:
-      ws:
-        optional: true
-      zod:
-        optional: true
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -4634,9 +4514,6 @@ packages:
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
-  secure-json-parse@2.7.0:
-    resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
-
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -4835,11 +4712,6 @@ packages:
   svg-parser@2.0.4:
     resolution: {integrity: sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==}
 
-  swr@2.4.0:
-    resolution: {integrity: sha512-sUlC20T8EOt1pHmDiqueUWMmRRX03W7w5YxovWX7VR2KHEPCTMly85x05vpkP5i6Bu4h44ePSMD9Tc+G2MItFw==}
-    peerDependencies:
-      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -4862,10 +4734,6 @@ packages:
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
-
-  throttleit@2.1.0:
-    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
-    engines: {node: '>=18'}
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
@@ -4892,9 +4760,6 @@ packages:
   tough-cookie@4.1.4:
     resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
     engines: {node: '>=6'}
-
-  tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   tr46@5.1.1:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
@@ -5271,13 +5136,6 @@ packages:
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
-  web-streams-polyfill@4.0.0-beta.3:
-    resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
-    engines: {node: '>= 14'}
-
-  webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
@@ -5297,9 +5155,6 @@ packages:
   whatwg-url@14.2.0:
     resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
     engines: {node: '>=18'}
-
-  whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -5384,11 +5239,6 @@ packages:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
     engines: {node: '>=12.20'}
 
-  zod-to-json-schema@3.25.1:
-    resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
-    peerDependencies:
-      zod: ^3.25 || ^4
-
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
@@ -5396,40 +5246,6 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
-
-  '@ai-sdk/openai@1.3.24(zod@4.3.6)':
-    dependencies:
-      '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@4.3.6)
-      zod: 4.3.6
-
-  '@ai-sdk/provider-utils@2.2.8(zod@4.3.6)':
-    dependencies:
-      '@ai-sdk/provider': 1.1.3
-      nanoid: 3.3.11
-      secure-json-parse: 2.7.0
-      zod: 4.3.6
-
-  '@ai-sdk/provider@1.1.3':
-    dependencies:
-      json-schema: 0.4.0
-
-  '@ai-sdk/react@1.2.12(react@18.3.1)(zod@4.3.6)':
-    dependencies:
-      '@ai-sdk/provider-utils': 2.2.8(zod@4.3.6)
-      '@ai-sdk/ui-utils': 1.2.11(zod@4.3.6)
-      react: 18.3.1
-      swr: 2.4.0(react@18.3.1)
-      throttleit: 2.1.0
-    optionalDependencies:
-      zod: 4.3.6
-
-  '@ai-sdk/ui-utils@1.2.11(zod@4.3.6)':
-    dependencies:
-      '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@4.3.6)
-      zod: 4.3.6
-      zod-to-json-schema: 3.25.1(zod@4.3.6)
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -6129,8 +5945,6 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
-
-  '@opentelemetry/api@1.9.0': {}
 
   '@parcel/watcher-android-arm64@2.5.6':
     optional: true
@@ -6889,8 +6703,6 @@ snapshots:
     dependencies:
       '@types/ms': 2.1.0
 
-  '@types/diff-match-patch@1.0.36': {}
-
   '@types/doctrine@0.0.9': {}
 
   '@types/estree-jsx@1.0.5':
@@ -6926,14 +6738,10 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
-  '@types/node-fetch@2.6.13':
-    dependencies:
-      '@types/node': 18.19.130
-      form-data: 4.0.5
-
   '@types/node@18.19.130':
     dependencies:
       undici-types: 5.26.5
+    optional: true
 
   '@types/prismjs@1.26.6': {}
 
@@ -7194,10 +7002,6 @@ snapshots:
 
   '@vue/shared@3.5.28': {}
 
-  abort-controller@3.0.0:
-    dependencies:
-      event-target-shim: 5.0.1
-
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -7209,22 +7013,6 @@ snapshots:
   acorn@8.15.0: {}
 
   agent-base@7.1.4: {}
-
-  agentkeepalive@4.6.0:
-    dependencies:
-      humanize-ms: 1.2.1
-
-  ai@4.3.19(react@18.3.1)(zod@4.3.6):
-    dependencies:
-      '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@4.3.6)
-      '@ai-sdk/react': 1.2.12(react@18.3.1)(zod@4.3.6)
-      '@ai-sdk/ui-utils': 1.2.11(zod@4.3.6)
-      '@opentelemetry/api': 1.9.0
-      jsondiffpatch: 0.6.0
-      zod: 4.3.6
-    optionalDependencies:
-      react: 18.3.1
 
   ajv-draft-04@1.0.0(ajv@8.13.0):
     optionalDependencies:
@@ -7730,8 +7518,6 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  diff-match-patch@1.0.5: {}
-
   diff-sequences@29.6.3: {}
 
   diff@8.0.3: {}
@@ -8087,8 +7873,6 @@ snapshots:
 
   esutils@2.0.3: {}
 
-  event-target-shim@5.0.1: {}
-
   eventemitter3@5.0.4: {}
 
   execa@8.0.1:
@@ -8179,8 +7963,6 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data-encoder@1.7.2: {}
-
   form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
@@ -8190,11 +7972,6 @@ snapshots:
       mime-types: 2.1.35
 
   format@0.2.2: {}
-
-  formdata-node@4.4.1:
-    dependencies:
-      node-domexception: 1.0.0
-      web-streams-polyfill: 4.0.0-beta.3
 
   fraction.js@5.3.4: {}
 
@@ -8483,10 +8260,6 @@ snapshots:
 
   human-signals@5.0.0: {}
 
-  humanize-ms@1.2.1:
-    dependencies:
-      ms: 2.1.3
-
   husky@9.1.7: {}
 
   iconv-lite@0.6.3:
@@ -8771,17 +8544,9 @@ snapshots:
 
   json-schema-traverse@1.0.0: {}
 
-  json-schema@0.4.0: {}
-
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json5@2.2.3: {}
-
-  jsondiffpatch@0.6.0:
-    dependencies:
-      '@types/diff-match-patch': 1.0.36
-      chalk: 5.6.2
-      diff-match-patch: 1.0.5
 
   jsonfile@6.2.0:
     dependencies:
@@ -9436,12 +9201,6 @@ snapshots:
 
   node-addon-api@7.1.1: {}
 
-  node-domexception@1.0.0: {}
-
-  node-fetch@2.7.0:
-    dependencies:
-      whatwg-url: 5.0.0
-
   node-releases@2.0.27: {}
 
   normalize-path@3.0.0: {}
@@ -9509,21 +9268,6 @@ snapshots:
       define-lazy-prop: 2.0.0
       is-docker: 2.2.1
       is-wsl: 2.2.0
-
-  openai@4.104.0(ws@8.19.0)(zod@4.3.6):
-    dependencies:
-      '@types/node': 18.19.130
-      '@types/node-fetch': 2.6.13
-      abort-controller: 3.0.0
-      agentkeepalive: 4.6.0
-      form-data-encoder: 1.7.2
-      formdata-node: 4.4.1
-      node-fetch: 2.7.0
-    optionalDependencies:
-      ws: 8.19.0
-      zod: 4.3.6
-    transitivePeerDependencies:
-      - encoding
 
   optionator@0.9.4:
     dependencies:
@@ -10373,8 +10117,6 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  secure-json-parse@2.7.0: {}
-
   semver@6.3.1: {}
 
   semver@7.5.4:
@@ -10602,12 +10344,6 @@ snapshots:
 
   svg-parser@2.0.4: {}
 
-  swr@2.4.0(react@18.3.1):
-    dependencies:
-      dequal: 2.0.3
-      react: 18.3.1
-      use-sync-external-store: 1.6.0(react@18.3.1)
-
   symbol-tree@3.2.4: {}
 
   tabbable@6.4.0: {}
@@ -10625,8 +10361,6 @@ snapshots:
       minimatch: 3.1.2
 
   text-table@0.2.0: {}
-
-  throttleit@2.1.0: {}
 
   tiny-invariant@1.3.3: {}
 
@@ -10651,8 +10385,6 @@ snapshots:
       punycode: 2.3.1
       universalify: 0.2.0
       url-parse: 1.5.10
-
-  tr46@0.0.3: {}
 
   tr46@5.1.1:
     dependencies:
@@ -10759,7 +10491,8 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
-  undici-types@5.26.5: {}
+  undici-types@5.26.5:
+    optional: true
 
   unified@11.0.5:
     dependencies:
@@ -11047,10 +10780,6 @@ snapshots:
 
   web-namespaces@2.0.1: {}
 
-  web-streams-polyfill@4.0.0-beta.3: {}
-
-  webidl-conversions@3.0.1: {}
-
   webidl-conversions@7.0.0: {}
 
   webpack-virtual-modules@0.6.2: {}
@@ -11065,11 +10794,6 @@ snapshots:
     dependencies:
       tr46: 5.1.1
       webidl-conversions: 7.0.0
-
-  whatwg-url@5.0.0:
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -11158,10 +10882,6 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.2.2: {}
-
-  zod-to-json-schema@3.25.1(zod@4.3.6):
-    dependencies:
-      zod: 4.3.6
 
   zod@4.3.6: {}
 

--- a/src/ChatInput/ChatInput.tsx
+++ b/src/ChatInput/ChatInput.tsx
@@ -1,6 +1,7 @@
 import {
   useState,
   ReactElement,
+  ReactNode,
   useRef,
   useMemo,
   ChangeEvent,
@@ -8,7 +9,8 @@ import {
   forwardRef,
   useImperativeHandle,
   useEffect,
-  useCallback
+  useCallback,
+  FC
 } from 'react';
 import { Button, cn } from 'reablocks';
 import SendIcon from '@/assets/send.svg?react';
@@ -17,6 +19,123 @@ import { ChatContext } from '@/ChatContext';
 import { FileInput } from './FileInput';
 import { RichTextInput, RichTextInputRef } from './RichTextInput';
 import { SuggestionConfig, MentionItem, SlashCommandItem } from './types';
+
+/**
+ * Context provided to render props (actions, prepend, append)
+ * for building custom input layouts.
+ */
+export interface ChatInputRenderContext {
+  /**
+   * Whether the chat is currently loading/streaming a response.
+   */
+  isLoading: boolean;
+
+  /**
+   * Whether the input is disabled.
+   */
+  disabled: boolean;
+
+  /**
+   * The current input message value.
+   */
+  message: string;
+
+  /**
+   * Send the current message.
+   */
+  sendMessage: () => void;
+
+  /**
+   * Stop the current response generation.
+   */
+  stopMessage: () => void;
+}
+
+export type ChatInputSlot =
+  | ReactNode
+  | ((context: ChatInputRenderContext) => ReactNode);
+
+export interface SendButtonProps {
+  /**
+   * Custom icon for the send button.
+   */
+  icon?: ReactElement;
+
+  /**
+   * Whether the button is disabled.
+   */
+  disabled?: boolean;
+
+  /**
+   * Click handler.
+   */
+  onClick?: () => void;
+
+  /**
+   * Additional CSS class names.
+   */
+  className?: string;
+}
+
+export const SendButton: FC<SendButtonProps> = ({
+  icon = <SendIcon />,
+  disabled,
+  onClick,
+  className
+}) => {
+  const { theme } = useContext(ChatContext);
+  return (
+    <Button
+      title="Send"
+      className={cn(theme.input.actions.send, className)}
+      onClick={onClick}
+      disabled={disabled}
+    >
+      {icon}
+    </Button>
+  );
+};
+
+export interface StopButtonProps {
+  /**
+   * Custom icon for the stop button.
+   */
+  icon?: ReactElement;
+
+  /**
+   * Whether the button is disabled.
+   */
+  disabled?: boolean;
+
+  /**
+   * Click handler.
+   */
+  onClick?: () => void;
+
+  /**
+   * Additional CSS class names.
+   */
+  className?: string;
+}
+
+export const StopButton: FC<StopButtonProps> = ({
+  icon = <StopIcon />,
+  disabled,
+  onClick,
+  className
+}) => {
+  const { theme } = useContext(ChatContext);
+  return (
+    <Button
+      title="Stop"
+      className={cn(theme.input.actions.stop, className)}
+      onClick={onClick}
+      disabled={disabled}
+    >
+      {icon}
+    </Button>
+  );
+};
 
 export interface ChatInputProps {
   /**
@@ -75,6 +194,25 @@ export interface ChatInputProps {
    * Whether to auto-focus the input on mount (default: true)
    */
   autoFocus?: boolean;
+
+  /**
+   * Custom content rendered above the editor, inside the input container.
+   * Accepts a ReactNode or a render function receiving ChatInputRenderContext.
+   */
+  prepend?: ChatInputSlot;
+
+  /**
+   * Custom content rendered below the editor, inside the input container.
+   * Accepts a ReactNode or a render function receiving ChatInputRenderContext.
+   */
+  append?: ChatInputSlot;
+
+  /**
+   * Custom actions area replacing the default send/stop/file buttons.
+   * Accepts a ReactNode or a render function receiving ChatInputRenderContext.
+   * When provided, the default action buttons are not rendered.
+   */
+  actions?: ChatInputSlot;
 }
 
 export interface ChatInputRef {
@@ -99,6 +237,19 @@ export interface ChatInputRef {
   insertText: (text: string) => void;
 }
 
+function resolveSlot(
+  slot: ChatInputSlot | undefined,
+  context: ChatInputRenderContext
+): ReactNode {
+  if (slot === undefined || slot === null) {
+    return null;
+  }
+  if (typeof slot === 'function') {
+    return slot(context);
+  }
+  return slot;
+}
+
 export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
   (
     {
@@ -112,7 +263,10 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
       commands,
       minHeight = 24,
       maxHeight = 200,
-      autoFocus = true
+      autoFocus = true,
+      prepend,
+      append,
+      actions
     },
     ref
   ) => {
@@ -201,9 +355,57 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
       [commands]
     );
 
+    const renderContext: ChatInputRenderContext = useMemo(
+      () => ({
+        isLoading: isLoading ?? false,
+        disabled: disabled ?? false,
+        message,
+        sendMessage: handleSendMessage,
+        stopMessage: stopMessage ?? (() => {})
+      }),
+      [isLoading, disabled, message, handleSendMessage, stopMessage]
+    );
+
+    const defaultActions = (
+      <>
+        {allowedFiles?.length > 0 && (
+          <FileInput
+            allowedFiles={allowedFiles}
+            onFileUpload={handleFileUpload}
+            isLoading={isLoading}
+            disabled={disabled}
+            attachIcon={attachIcon}
+          />
+        )}
+        {isLoading && (
+          <StopButton
+            icon={stopIcon}
+            onClick={stopMessage}
+            disabled={disabled}
+          />
+        )}
+        <SendButton
+          icon={sendIcon}
+          onClick={handleSendMessage}
+          disabled={isLoading || disabled}
+        />
+      </>
+    );
+
+    const resolvedPrepend = resolveSlot(prepend, renderContext);
+    const resolvedAppend = resolveSlot(append, renderContext);
+    const resolvedActions =
+      actions !== undefined
+        ? resolveSlot(actions, renderContext)
+        : defaultActions;
+
     return (
       <div ref={containerRef} className={cn(theme.input.base)}>
         <div className={cn('relative flex-1', theme.input.input)}>
+          {resolvedPrepend && (
+            <div className={cn(theme.input.prepend)}>{resolvedPrepend}</div>
+          )}
+
           <RichTextInput
             ref={inputRef}
             value={message}
@@ -219,35 +421,11 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
             commands={commandsConfig}
           />
 
-          <div className={cn(theme.input.actions.base)}>
-            {allowedFiles?.length > 0 && (
-              <FileInput
-                allowedFiles={allowedFiles}
-                onFileUpload={handleFileUpload}
-                isLoading={isLoading}
-                disabled={disabled}
-                attachIcon={attachIcon}
-              />
-            )}
-            {isLoading && (
-              <Button
-                title="Stop"
-                className={cn(theme.input.actions.stop)}
-                onClick={stopMessage}
-                disabled={disabled}
-              >
-                {stopIcon}
-              </Button>
-            )}
-            <Button
-              title="Send"
-              className={cn(theme.input.actions.send)}
-              onClick={handleSendMessage}
-              disabled={isLoading || disabled}
-            >
-              {sendIcon}
-            </Button>
-          </div>
+          {resolvedAppend && (
+            <div className={cn(theme.input.append)}>{resolvedAppend}</div>
+          )}
+
+          <div className={cn(theme.input.actions.base)}>{resolvedActions}</div>
         </div>
       </div>
     );

--- a/src/ChatInput/ChatInput.tsx
+++ b/src/ChatInput/ChatInput.tsx
@@ -16,6 +16,7 @@ import { Button, cn } from 'reablocks';
 import SendIcon from '@/assets/send.svg?react';
 import StopIcon from '@/assets/stop.svg?react';
 import { ChatContext } from '@/ChatContext';
+import { chatTheme as defaultTheme } from '@/theme';
 import { FileInput } from './FileInput';
 import { RichTextInput, RichTextInputRef } from './RichTextInput';
 import { SuggestionConfig, MentionItem, SlashCommandItem } from './types';
@@ -84,10 +85,12 @@ export const SendButton: FC<SendButtonProps> = ({
   className
 }) => {
   const { theme } = useContext(ChatContext);
+  const sendClass =
+    theme?.input?.actions?.send ?? defaultTheme.input.actions.send;
   return (
     <Button
       title="Send"
-      className={cn(theme.input.actions.send, className)}
+      className={cn(sendClass, className)}
       onClick={onClick}
       disabled={disabled}
     >
@@ -125,10 +128,12 @@ export const StopButton: FC<StopButtonProps> = ({
   className
 }) => {
   const { theme } = useContext(ChatContext);
+  const stopClass =
+    theme?.input?.actions?.stop ?? defaultTheme.input.actions.stop;
   return (
     <Button
       title="Stop"
-      className={cn(theme.input.actions.stop, className)}
+      className={cn(stopClass, className)}
       onClick={onClick}
       disabled={disabled}
     >
@@ -441,8 +446,14 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
 
     return (
       <div ref={containerRef} className={cn(theme.input.base)}>
-        <div className={cn('relative flex-1', theme.input.input)}>
-          {resolvedPrepend && (
+        <div
+          className={cn(
+            'relative flex-1',
+            theme.input.input,
+            actionsPlacement === 'inline' && 'pr-16'
+          )}
+        >
+          {resolvedPrepend != null && (
             <div className={cn(theme.input.prepend)}>{resolvedPrepend}</div>
           )}
 
@@ -460,7 +471,7 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
 
           {actionsPlacement === 'bottom' && actionsBlock}
 
-          {resolvedAppend && (
+          {resolvedAppend != null && (
             <div className={cn(theme.input.append)}>{resolvedAppend}</div>
           )}
 

--- a/src/ChatInput/ChatInput.tsx
+++ b/src/ChatInput/ChatInput.tsx
@@ -213,6 +213,16 @@ export interface ChatInputProps {
    * When provided, the default action buttons are not rendered.
    */
   actions?: ChatInputSlot;
+
+  /**
+   * Where to place the actions relative to the editor.
+   * - 'inline': Absolutely positioned over the editor (default)
+   * - 'top': Rendered as a block row above the editor
+   * - 'bottom': Rendered as a block row below the editor
+   * - 'before': Rendered to the left of the editor
+   * - 'after': Rendered to the right of the editor
+   */
+  actionsPlacement?: 'inline' | 'top' | 'bottom' | 'before' | 'after';
 }
 
 export interface ChatInputRef {
@@ -266,7 +276,8 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
       autoFocus = true,
       prepend,
       append,
-      actions
+      actions,
+      actionsPlacement = 'inline'
     },
     ref
   ) => {
@@ -399,6 +410,35 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
         ? resolveSlot(actions, renderContext)
         : defaultActions;
 
+    const actionsTheme =
+      actionsPlacement === 'inline'
+        ? theme.input.actions.base
+        : theme.input.actions[actionsPlacement];
+
+    const actionsBlock = (
+      <div className={cn(actionsTheme)}>{resolvedActions}</div>
+    );
+
+    const isHorizontal =
+      actionsPlacement === 'before' || actionsPlacement === 'after';
+
+    const editorNode = (
+      <RichTextInput
+        ref={inputRef}
+        value={message}
+        onChange={handleChange}
+        onSubmit={handleSubmit}
+        placeholder={placeholder}
+        disabled={isLoading || disabled}
+        autoFocus={autoFocus}
+        minHeight={minHeight}
+        maxHeight={maxHeight}
+        className={theme.input.editor.container}
+        mentions={mentionsConfig}
+        commands={commandsConfig}
+      />
+    );
+
     return (
       <div ref={containerRef} className={cn(theme.input.base)}>
         <div className={cn('relative flex-1', theme.input.input)}>
@@ -406,26 +446,25 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
             <div className={cn(theme.input.prepend)}>{resolvedPrepend}</div>
           )}
 
-          <RichTextInput
-            ref={inputRef}
-            value={message}
-            onChange={handleChange}
-            onSubmit={handleSubmit}
-            placeholder={placeholder}
-            disabled={isLoading || disabled}
-            autoFocus={autoFocus}
-            minHeight={minHeight}
-            maxHeight={maxHeight}
-            className={theme.input.editor.container}
-            mentions={mentionsConfig}
-            commands={commandsConfig}
-          />
+          {actionsPlacement === 'top' && actionsBlock}
+
+          {isHorizontal ? (
+            <div className="flex items-center gap-2">
+              {actionsPlacement === 'before' && actionsBlock}
+              <div className="flex-1">{editorNode}</div>
+              {actionsPlacement === 'after' && actionsBlock}
+            </div>
+          ) : (
+            editorNode
+          )}
+
+          {actionsPlacement === 'bottom' && actionsBlock}
 
           {resolvedAppend && (
             <div className={cn(theme.input.append)}>{resolvedAppend}</div>
           )}
 
-          <div className={cn(theme.input.actions.base)}>{resolvedActions}</div>
+          {actionsPlacement === 'inline' && actionsBlock}
         </div>
       </div>
     );

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -316,7 +316,7 @@ export const chatTheme: ChatTheme = {
     prepend: '',
     append: '',
     input: [
-      'w-full border rounded-3xl px-3 py-2 pr-16 text-gray-500 border-gray-200 hover:bg-blue-100 hover:border-blue-500 after:hidden after:mx-10! bg-white [&>textarea]:w-full [&>textarea]:flex-none',
+      'w-full border rounded-3xl px-3 py-2 text-gray-500 border-gray-200 hover:bg-blue-100 hover:border-blue-500 after:hidden after:mx-10! bg-white [&>textarea]:w-full [&>textarea]:flex-none',
       'dark:border-gray-700/50 dark:text-gray-200 dark:bg-gray-950 dark:hover:bg-blue-950/40'
     ].join(' '),
     actions: {

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -108,6 +108,8 @@ export interface ChatTheme {
     base: string;
     upload: string;
     input: string;
+    prepend: string;
+    append: string;
     actions: {
       base: string;
       send: string;
@@ -307,6 +309,8 @@ export const chatTheme: ChatTheme = {
   input: {
     base: 'flex mt-4 relative',
     upload: ['px-5 py-2 text-gray-400 size-10', 'dark:gray-500'].join(' '),
+    prepend: '',
+    append: '',
     input: [
       'w-full border rounded-3xl px-3 py-2 pr-16 text-gray-500 border-gray-200 hover:bg-blue-100 hover:border-blue-500 after:hidden after:mx-10! bg-white [&>textarea]:w-full [&>textarea]:flex-none',
       'dark:border-gray-700/50 dark:text-gray-200 dark:bg-gray-950 dark:hover:bg-blue-950/40'

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -112,6 +112,10 @@ export interface ChatTheme {
     append: string;
     actions: {
       base: string;
+      top: string;
+      bottom: string;
+      before: string;
+      after: string;
       send: string;
       stop: string;
     };
@@ -317,6 +321,10 @@ export const chatTheme: ChatTheme = {
     ].join(' '),
     actions: {
       base: 'absolute flex gap-2 items-center right-5 inset-y-1/2 -translate-y-1/2 z-10',
+      top: 'flex gap-2 items-center justify-end px-2 pt-1',
+      bottom: 'flex gap-2 items-center justify-end px-2 pb-1',
+      before: 'flex gap-2 items-center',
+      after: 'flex gap-2 items-center',
       send: [
         'px-3 py-3 hover:bg-primary-hover rounded-full bg-gray-200 hover:bg-gray-300 text-gray-500',
         'dark:text-white light:text-gray-500 dark:bg-gray-800 dark:hover:bg-gray-700'

--- a/stories/CustomInputLayout.stories.tsx
+++ b/stories/CustomInputLayout.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryFn } from '@storybook/react';
-import { useState, useCallback } from 'react';
+import { useState } from 'react';
 import {
   Chat,
   SessionMessages,

--- a/stories/CustomInputLayout.stories.tsx
+++ b/stories/CustomInputLayout.stories.tsx
@@ -1,0 +1,398 @@
+import { Meta, StoryFn } from '@storybook/react';
+import { useState, useCallback } from 'react';
+import {
+  Chat,
+  SessionMessages,
+  ChatInput,
+  SessionMessagePanel,
+  Session,
+  SendButton,
+  StopButton,
+  ChatInputRenderContext
+} from '../src';
+import { fakeSessions, createSendMessageHandler } from './examples';
+
+export default {
+  title: 'Demos/Custom Input Layout',
+  component: ChatInput
+} as Meta;
+
+const ChevronDownIcon = () => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    className="w-3.5 h-3.5"
+  >
+    <polyline points="6 9 12 15 18 9" />
+  </svg>
+);
+
+const BoltIcon = () => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    className="w-4 h-4"
+  >
+    <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />
+  </svg>
+);
+
+const PaperclipIcon = () => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    className="w-4 h-4"
+  >
+    <path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48" />
+  </svg>
+);
+
+const GlobeIcon = () => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    className="w-4 h-4"
+  >
+    <circle cx="12" cy="12" r="10" />
+    <line x1="2" y1="12" x2="22" y2="12" />
+    <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+  </svg>
+);
+
+/**
+ * Demonstrates a model selector dropdown rendered in the `append` slot,
+ * below the text editor but inside the input container.
+ */
+export const WithModelSelector: StoryFn = () => {
+  const [activeId, setActiveId] = useState<string>(fakeSessions[0].id);
+  const [sessions, setSessions] = useState<Session[]>(fakeSessions);
+  const [selectedModel, setSelectedModel] = useState('GPT-4o');
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+
+  const models = [
+    { id: 'gpt-4o', label: 'GPT-4o', description: 'Most capable' },
+    { id: 'gpt-4o-mini', label: 'GPT-4o Mini', description: 'Fast & cheap' },
+    { id: 'claude-sonnet', label: 'Claude Sonnet', description: 'Balanced' },
+    { id: 'claude-haiku', label: 'Claude Haiku', description: 'Fastest' }
+  ];
+
+  return (
+    <div
+      className="dark:bg-gray-950 bg-white"
+      style={{ width: 600, height: 500, padding: 20, borderRadius: 5 }}
+    >
+      <Chat
+        viewType="chat"
+        sessions={sessions}
+        activeSessionId={activeId}
+        onSelectSession={setActiveId}
+        onSendMessage={createSendMessageHandler(setSessions, activeId)}
+      >
+        <SessionMessagePanel>
+          <SessionMessages />
+          <ChatInput
+            placeholder="Ask anything..."
+            append={
+              <div className="flex items-center gap-2 px-1 pb-1">
+                <div className="relative">
+                  <button
+                    type="button"
+                    onClick={() => setDropdownOpen(!dropdownOpen)}
+                    className="flex items-center gap-1.5 px-2.5 py-1 text-xs rounded-lg
+                      bg-gray-100 hover:bg-gray-200 text-gray-600
+                      dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-300
+                      transition-colors cursor-pointer"
+                  >
+                    <BoltIcon />
+                    {selectedModel}
+                    <ChevronDownIcon />
+                  </button>
+                  {dropdownOpen && (
+                    <div
+                      className="absolute bottom-full left-0 mb-1 w-48 py-1
+                        bg-white border border-gray-200 rounded-lg shadow-lg
+                        dark:bg-gray-900 dark:border-gray-700 z-20"
+                    >
+                      {models.map(model => (
+                        <button
+                          key={model.id}
+                          type="button"
+                          onClick={() => {
+                            setSelectedModel(model.label);
+                            setDropdownOpen(false);
+                          }}
+                          className={`w-full text-left px-3 py-2 text-sm cursor-pointer
+                            hover:bg-gray-100 dark:hover:bg-gray-800
+                            ${selectedModel === model.label ? 'bg-gray-50 dark:bg-gray-800/50' : ''}
+                          `}
+                        >
+                          <div className="font-medium text-gray-900 dark:text-gray-100">
+                            {model.label}
+                          </div>
+                          <div className="text-xs text-gray-500 dark:text-gray-400">
+                            {model.description}
+                          </div>
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            }
+          />
+        </SessionMessagePanel>
+      </Chat>
+    </div>
+  );
+};
+
+/**
+ * Demonstrates a toolbar in the `prepend` slot with quick-action buttons
+ * rendered above the text editor.
+ */
+export const WithToolbar: StoryFn = () => {
+  const [activeId, setActiveId] = useState<string>(fakeSessions[0].id);
+  const [sessions, setSessions] = useState<Session[]>(fakeSessions);
+  const [webSearch, setWebSearch] = useState(false);
+
+  return (
+    <div
+      className="dark:bg-gray-950 bg-white"
+      style={{ width: 600, height: 500, padding: 20, borderRadius: 5 }}
+    >
+      <Chat
+        viewType="chat"
+        sessions={sessions}
+        activeSessionId={activeId}
+        onSelectSession={setActiveId}
+        onSendMessage={createSendMessageHandler(setSessions, activeId)}
+      >
+        <SessionMessagePanel>
+          <SessionMessages />
+          <ChatInput
+            placeholder="Ask anything..."
+            prepend={
+              <div className="flex items-center gap-1 px-1 pt-1">
+                <button
+                  type="button"
+                  onClick={() => setWebSearch(!webSearch)}
+                  className={`flex items-center gap-1.5 px-2.5 py-1 text-xs rounded-lg
+                    transition-colors cursor-pointer
+                    ${
+                      webSearch
+                        ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300'
+                        : 'bg-gray-100 hover:bg-gray-200 text-gray-600 dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-300'
+                    }`}
+                >
+                  <GlobeIcon />
+                  Web Search
+                </button>
+                <button
+                  type="button"
+                  className="flex items-center gap-1.5 px-2.5 py-1 text-xs rounded-lg
+                    bg-gray-100 hover:bg-gray-200 text-gray-600
+                    dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-300
+                    transition-colors cursor-pointer"
+                >
+                  <PaperclipIcon />
+                  Attach
+                </button>
+              </div>
+            }
+          />
+        </SessionMessagePanel>
+      </Chat>
+    </div>
+  );
+};
+
+/**
+ * Demonstrates the `actions` render prop for fully custom action buttons.
+ * The render function receives ChatInputRenderContext with state and callbacks.
+ */
+export const WithCustomActions: StoryFn = () => {
+  const [activeId, setActiveId] = useState<string>(fakeSessions[0].id);
+  const [sessions, setSessions] = useState<Session[]>(fakeSessions);
+
+  return (
+    <div
+      className="dark:bg-gray-950 bg-white"
+      style={{ width: 600, height: 500, padding: 20, borderRadius: 5 }}
+    >
+      <Chat
+        viewType="chat"
+        sessions={sessions}
+        activeSessionId={activeId}
+        onSelectSession={setActiveId}
+        onSendMessage={createSendMessageHandler(setSessions, activeId)}
+      >
+        <SessionMessagePanel>
+          <SessionMessages />
+          <ChatInput
+            placeholder="Ask anything..."
+            actions={(ctx: ChatInputRenderContext) => (
+              <>
+                {ctx.isLoading ? (
+                  <StopButton onClick={ctx.stopMessage} />
+                ) : (
+                  <>
+                    <button
+                      type="button"
+                      className="px-2 py-2 text-xs rounded-full
+                        bg-gray-100 hover:bg-gray-200 text-gray-500
+                        dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-300
+                        transition-colors cursor-pointer"
+                      title="Attach file"
+                    >
+                      <PaperclipIcon />
+                    </button>
+                    <SendButton
+                      onClick={ctx.sendMessage}
+                      disabled={ctx.disabled || !ctx.message.trim()}
+                    />
+                  </>
+                )}
+              </>
+            )}
+          />
+        </SessionMessagePanel>
+      </Chat>
+    </div>
+  );
+};
+
+/**
+ * Combines all customization options: prepend toolbar, append model selector,
+ * and custom actions with the reusable SendButton/StopButton components.
+ */
+export const FullCustomLayout: StoryFn = () => {
+  const [activeId, setActiveId] = useState<string>(fakeSessions[0].id);
+  const [sessions, setSessions] = useState<Session[]>(fakeSessions);
+  const [selectedModel, setSelectedModel] = useState('GPT-4o');
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [webSearch, setWebSearch] = useState(false);
+
+  const models = [
+    { id: 'gpt-4o', label: 'GPT-4o', description: 'Most capable' },
+    { id: 'gpt-4o-mini', label: 'GPT-4o Mini', description: 'Fast & cheap' },
+    { id: 'claude-sonnet', label: 'Claude Sonnet', description: 'Balanced' },
+    { id: 'claude-haiku', label: 'Claude Haiku', description: 'Fastest' }
+  ];
+
+  return (
+    <div
+      className="dark:bg-gray-950 bg-white"
+      style={{ width: 600, height: 500, padding: 20, borderRadius: 5 }}
+    >
+      <Chat
+        viewType="chat"
+        sessions={sessions}
+        activeSessionId={activeId}
+        onSelectSession={setActiveId}
+        onSendMessage={createSendMessageHandler(setSessions, activeId)}
+      >
+        <SessionMessagePanel>
+          <SessionMessages />
+          <ChatInput
+            placeholder="Ask anything..."
+            prepend={
+              <div className="flex items-center gap-1 px-1 pt-1">
+                <button
+                  type="button"
+                  onClick={() => setWebSearch(!webSearch)}
+                  className={`flex items-center gap-1.5 px-2.5 py-1 text-xs rounded-lg
+                    transition-colors cursor-pointer
+                    ${
+                      webSearch
+                        ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300'
+                        : 'bg-gray-100 hover:bg-gray-200 text-gray-600 dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-300'
+                    }`}
+                >
+                  <GlobeIcon />
+                  Web Search
+                </button>
+                <button
+                  type="button"
+                  className="flex items-center gap-1.5 px-2.5 py-1 text-xs rounded-lg
+                    bg-gray-100 hover:bg-gray-200 text-gray-600
+                    dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-300
+                    transition-colors cursor-pointer"
+                >
+                  <PaperclipIcon />
+                  Attach
+                </button>
+              </div>
+            }
+            append={
+              <div className="flex items-center gap-2 px-1 pb-1">
+                <div className="relative">
+                  <button
+                    type="button"
+                    onClick={() => setDropdownOpen(!dropdownOpen)}
+                    className="flex items-center gap-1.5 px-2.5 py-1 text-xs rounded-lg
+                      bg-gray-100 hover:bg-gray-200 text-gray-600
+                      dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-300
+                      transition-colors cursor-pointer"
+                  >
+                    <BoltIcon />
+                    {selectedModel}
+                    <ChevronDownIcon />
+                  </button>
+                  {dropdownOpen && (
+                    <div
+                      className="absolute bottom-full left-0 mb-1 w-48 py-1
+                        bg-white border border-gray-200 rounded-lg shadow-lg
+                        dark:bg-gray-900 dark:border-gray-700 z-20"
+                    >
+                      {models.map(model => (
+                        <button
+                          key={model.id}
+                          type="button"
+                          onClick={() => {
+                            setSelectedModel(model.label);
+                            setDropdownOpen(false);
+                          }}
+                          className={`w-full text-left px-3 py-2 text-sm cursor-pointer
+                            hover:bg-gray-100 dark:hover:bg-gray-800
+                            ${selectedModel === model.label ? 'bg-gray-50 dark:bg-gray-800/50' : ''}
+                          `}
+                        >
+                          <div className="font-medium text-gray-900 dark:text-gray-100">
+                            {model.label}
+                          </div>
+                          <div className="text-xs text-gray-500 dark:text-gray-400">
+                            {model.description}
+                          </div>
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            }
+            actions={(ctx: ChatInputRenderContext) => (
+              <>
+                {ctx.isLoading ? (
+                  <StopButton onClick={ctx.stopMessage} />
+                ) : (
+                  <SendButton
+                    onClick={ctx.sendMessage}
+                    disabled={ctx.disabled || !ctx.message.trim()}
+                  />
+                )}
+              </>
+            )}
+          />
+        </SessionMessagePanel>
+      </Chat>
+    </div>
+  );
+};

--- a/stories/CustomInputLayout.stories.tsx
+++ b/stories/CustomInputLayout.stories.tsx
@@ -187,10 +187,10 @@ export const WithToolbar: StoryFn = () => {
                   className={`flex items-center gap-1.5 px-2.5 py-1 text-xs rounded-lg
                     transition-colors cursor-pointer
                     ${
-                      webSearch
-                        ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300'
-                        : 'bg-gray-100 hover:bg-gray-200 text-gray-600 dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-300'
-                    }`}
+    webSearch
+      ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300'
+      : 'bg-gray-100 hover:bg-gray-200 text-gray-600 dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-300'
+    }`}
                 >
                   <GlobeIcon />
                   Web Search
@@ -311,10 +311,10 @@ export const FullCustomLayout: StoryFn = () => {
                   className={`flex items-center gap-1.5 px-2.5 py-1 text-xs rounded-lg
                     transition-colors cursor-pointer
                     ${
-                      webSearch
-                        ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300'
-                        : 'bg-gray-100 hover:bg-gray-200 text-gray-600 dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-300'
-                    }`}
+    webSearch
+      ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300'
+      : 'bg-gray-100 hover:bg-gray-200 text-gray-600 dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-300'
+    }`}
                 >
                   <GlobeIcon />
                   Web Search
@@ -390,6 +390,219 @@ export const FullCustomLayout: StoryFn = () => {
                 )}
               </>
             )}
+          />
+        </SessionMessagePanel>
+      </Chat>
+    </div>
+  );
+};
+
+/**
+ * Demonstrates `actionsPlacement="bottom"` which renders the action buttons
+ * as a row below the text editor instead of overlaying it.
+ */
+export const ActionsBottom: StoryFn = () => {
+  const [activeId, setActiveId] = useState<string>(fakeSessions[0].id);
+  const [sessions, setSessions] = useState<Session[]>(fakeSessions);
+  const [selectedModel, setSelectedModel] = useState('GPT-4o');
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+
+  const models = [
+    { id: 'gpt-4o', label: 'GPT-4o', description: 'Most capable' },
+    { id: 'gpt-4o-mini', label: 'GPT-4o Mini', description: 'Fast & cheap' },
+    { id: 'claude-sonnet', label: 'Claude Sonnet', description: 'Balanced' },
+    { id: 'claude-haiku', label: 'Claude Haiku', description: 'Fastest' }
+  ];
+
+  return (
+    <div
+      className="dark:bg-gray-950 bg-white"
+      style={{ width: 600, height: 500, padding: 20, borderRadius: 5 }}
+    >
+      <Chat
+        viewType="chat"
+        sessions={sessions}
+        activeSessionId={activeId}
+        onSelectSession={setActiveId}
+        onSendMessage={createSendMessageHandler(setSessions, activeId)}
+      >
+        <SessionMessagePanel>
+          <SessionMessages />
+          <ChatInput
+            placeholder="Ask anything..."
+            actionsPlacement="bottom"
+            actions={(ctx: ChatInputRenderContext) => (
+              <div className="flex items-center justify-between w-full">
+                <div className="relative">
+                  <button
+                    type="button"
+                    onClick={() => setDropdownOpen(!dropdownOpen)}
+                    className="flex items-center gap-1.5 px-2.5 py-1 text-xs rounded-lg
+                      bg-gray-100 hover:bg-gray-200 text-gray-600
+                      dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-300
+                      transition-colors cursor-pointer"
+                  >
+                    <BoltIcon />
+                    {selectedModel}
+                    <ChevronDownIcon />
+                  </button>
+                  {dropdownOpen && (
+                    <div
+                      className="absolute bottom-full left-0 mb-1 w-48 py-1
+                        bg-white border border-gray-200 rounded-lg shadow-lg
+                        dark:bg-gray-900 dark:border-gray-700 z-20"
+                    >
+                      {models.map(model => (
+                        <button
+                          key={model.id}
+                          type="button"
+                          onClick={() => {
+                            setSelectedModel(model.label);
+                            setDropdownOpen(false);
+                          }}
+                          className={`w-full text-left px-3 py-2 text-sm cursor-pointer
+                            hover:bg-gray-100 dark:hover:bg-gray-800
+                            ${selectedModel === model.label ? 'bg-gray-50 dark:bg-gray-800/50' : ''}
+                          `}
+                        >
+                          <div className="font-medium text-gray-900 dark:text-gray-100">
+                            {model.label}
+                          </div>
+                          <div className="text-xs text-gray-500 dark:text-gray-400">
+                            {model.description}
+                          </div>
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+                <div className="flex items-center gap-2">
+                  {ctx.isLoading ? (
+                    <StopButton onClick={ctx.stopMessage} />
+                  ) : (
+                    <SendButton
+                      onClick={ctx.sendMessage}
+                      disabled={ctx.disabled || !ctx.message.trim()}
+                    />
+                  )}
+                </div>
+              </div>
+            )}
+          />
+        </SessionMessagePanel>
+      </Chat>
+    </div>
+  );
+};
+
+/**
+ * Demonstrates `actionsPlacement="top"` which renders the action buttons
+ * as a row above the text editor.
+ */
+export const ActionsTop: StoryFn = () => {
+  const [activeId, setActiveId] = useState<string>(fakeSessions[0].id);
+  const [sessions, setSessions] = useState<Session[]>(fakeSessions);
+
+  return (
+    <div
+      className="dark:bg-gray-950 bg-white"
+      style={{ width: 600, height: 500, padding: 20, borderRadius: 5 }}
+    >
+      <Chat
+        viewType="chat"
+        sessions={sessions}
+        activeSessionId={activeId}
+        onSelectSession={setActiveId}
+        onSendMessage={createSendMessageHandler(setSessions, activeId)}
+      >
+        <SessionMessagePanel>
+          <SessionMessages />
+          <ChatInput
+            placeholder="Ask anything..."
+            actionsPlacement="top"
+            actions={(ctx: ChatInputRenderContext) => (
+              <div className="flex items-center justify-between w-full">
+                <span className="text-xs text-gray-400 dark:text-gray-500">
+                  {ctx.message.length > 0
+                    ? `${ctx.message.length} characters`
+                    : 'Start typing...'}
+                </span>
+                <div className="flex items-center gap-2">
+                  {ctx.isLoading ? (
+                    <StopButton onClick={ctx.stopMessage} />
+                  ) : (
+                    <SendButton
+                      onClick={ctx.sendMessage}
+                      disabled={ctx.disabled || !ctx.message.trim()}
+                    />
+                  )}
+                </div>
+              </div>
+            )}
+          />
+        </SessionMessagePanel>
+      </Chat>
+    </div>
+  );
+};
+
+/**
+ * Demonstrates `actionsPlacement="after"` which renders the action buttons
+ * to the right of the editor on the same row.
+ */
+export const ActionsAfter: StoryFn = () => {
+  const [activeId, setActiveId] = useState<string>(fakeSessions[0].id);
+  const [sessions, setSessions] = useState<Session[]>(fakeSessions);
+
+  return (
+    <div
+      className="dark:bg-gray-950 bg-white"
+      style={{ width: 600, height: 500, padding: 20, borderRadius: 5 }}
+    >
+      <Chat
+        viewType="chat"
+        sessions={sessions}
+        activeSessionId={activeId}
+        onSelectSession={setActiveId}
+        onSendMessage={createSendMessageHandler(setSessions, activeId)}
+      >
+        <SessionMessagePanel>
+          <SessionMessages />
+          <ChatInput
+            placeholder="Ask anything..."
+            actionsPlacement="after"
+          />
+        </SessionMessagePanel>
+      </Chat>
+    </div>
+  );
+};
+
+/**
+ * Demonstrates `actionsPlacement="before"` which renders the action buttons
+ * to the left of the editor on the same row.
+ */
+export const ActionsBefore: StoryFn = () => {
+  const [activeId, setActiveId] = useState<string>(fakeSessions[0].id);
+  const [sessions, setSessions] = useState<Session[]>(fakeSessions);
+
+  return (
+    <div
+      className="dark:bg-gray-950 bg-white"
+      style={{ width: 600, height: 500, padding: 20, borderRadius: 5 }}
+    >
+      <Chat
+        viewType="chat"
+        sessions={sessions}
+        activeSessionId={activeId}
+        onSelectSession={setActiveId}
+        onSendMessage={createSendMessageHandler(setSessions, activeId)}
+      >
+        <SessionMessagePanel>
+          <SessionMessages />
+          <ChatInput
+            placeholder="Ask anything..."
+            actionsPlacement="before"
           />
         </SessionMessagePanel>
       </Chat>


### PR DESCRIPTION
Add prepend, append, and actions slot props to ChatInput for flexible layout
customization. Each slot accepts a ReactNode or a render function that receives
ChatInputRenderContext (isLoading, disabled, message, sendMessage, stopMessage).

Extract SendButton and StopButton as standalone exported components so users can
compose custom action layouts while reusing the default themed buttons.

Add new Storybook demos: model selector, toolbar, custom actions, and full
custom layout combining all slots.

https://claude.ai/code/session_01ATC3T4KBTV5pXpzDTL5Zz7