### PR TITLE
Fix remarkCve to produce valid inline link nodes

### DIFF
--- a/src/Markdown/plugins/remarkCve.spec.ts
+++ b/src/Markdown/plugins/remarkCve.spec.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest';
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import type { Root, Link, Paragraph, Text, List } from 'mdast';
+import { remarkCve } from './remarkCve';
+
+const parse = (md: string): Root =>
+  unified().use(remarkParse).use(remarkCve).parse(md) as Root;
+
+const process = (md: string): Root => {
+  const processor = unified().use(remarkParse).use(remarkCve);
+  const tree = processor.parse(md) as Root;
+  return processor.runSync(tree) as Root;
+};
+
+describe('remarkCve', () => {
+  it('replaces a CVE id inside a paragraph with an inline link', () => {
+    const tree = process('See CVE-2021-34527 for details.');
+    const paragraph = tree.children[0] as Paragraph;
+
+    expect(paragraph.type).toBe('paragraph');
+    expect(paragraph.children).toHaveLength(3);
+
+    const [before, link, after] = paragraph.children as [Text, Link, Text];
+    expect(before.type).toBe('text');
+    expect(before.value).toBe('See ');
+
+    expect(link.type).toBe('link');
+    expect(link.url).toBe(
+      'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-34527'
+    );
+    expect(link.children).toHaveLength(1);
+    const linkText = link.children[0] as Text;
+    expect(linkText.type).toBe('text');
+    expect(linkText.value).toBe('CVE-2021-34527');
+
+    expect(after.type).toBe('text');
+    expect(after.value).toBe(' for details.');
+  });
+
+  it('does not wrap the link in an extra paragraph (keeps it inline)', () => {
+    const tree = process('CVE-2021-44228');
+    expect(tree.children).toHaveLength(1);
+    const paragraph = tree.children[0] as Paragraph;
+    expect(paragraph.type).toBe('paragraph');
+    expect(paragraph.children[0].type).toBe('link');
+  });
+
+  it('replaces multiple CVE ids in the same paragraph', () => {
+    const tree = process('CVE-2021-34527 and CVE-2021-44228 are critical.');
+    const paragraph = tree.children[0] as Paragraph;
+    const links = paragraph.children.filter(
+      (n): n is Link => n.type === 'link'
+    );
+    expect(links).toHaveLength(2);
+    expect(links[0].url).toContain('CVE-2021-34527');
+    expect(links[1].url).toContain('CVE-2021-44228');
+  });
+
+  it('replaces CVE ids inside list items', () => {
+    const md = ['- CVE-2021-34527', '- CVE-2021-44228'].join('\n');
+    const tree = process(md);
+    const list = tree.children[0] as List;
+    expect(list.type).toBe('list');
+
+    list.children.forEach((item, idx) => {
+      const para = item.children[0] as Paragraph;
+      const link = para.children[0] as Link;
+      expect(link.type).toBe('link');
+      expect(link.url).toContain(
+        idx === 0 ? 'CVE-2021-34527' : 'CVE-2021-44228'
+      );
+      const linkText = link.children[0] as Text;
+      expect(linkText.type).toBe('text');
+      expect(linkText.value).toBe(
+        idx === 0 ? 'CVE-2021-34527' : 'CVE-2021-44228'
+      );
+    });
+  });
+
+  it('matches CVE ids case-insensitively but preserves casing in output', () => {
+    const tree = process('cve-2021-34527');
+    const paragraph = tree.children[0] as Paragraph;
+    const link = paragraph.children[0] as Link;
+    expect(link.type).toBe('link');
+    expect(link.url).toBe(
+      'https://cve.mitre.org/cgi-bin/cvename.cgi?name=cve-2021-34527'
+    );
+    const linkText = link.children[0] as Text;
+    expect(linkText.value).toBe('cve-2021-34527');
+  });
+
+  it('supports CVE ids with up to 7 digits in the suffix', () => {
+    const tree = process('CVE-2024-1234567 was reported.');
+    const paragraph = tree.children[0] as Paragraph;
+    const link = paragraph.children.find((n): n is Link => n.type === 'link');
+    expect(link).toBeDefined();
+    expect(link!.url).toContain('CVE-2024-1234567');
+  });
+
+  it('does not replace strings that look like but are not CVEs', () => {
+    const tree = process('CVE-1899-1234 and CVE-2021-12 are not valid.');
+    const paragraph = tree.children[0] as Paragraph;
+    const links = paragraph.children.filter(
+      (n): n is Link => n.type === 'link'
+    );
+    expect(links).toHaveLength(0);
+  });
+
+  it('leaves non-CVE markdown untouched', () => {
+    const tree = process('Hello world, no vulnerabilities here.');
+    const paragraph = tree.children[0] as Paragraph;
+    expect(paragraph.children).toHaveLength(1);
+    expect(paragraph.children[0].type).toBe('text');
+  });
+
+  it('produces a valid mdast link node (children are phrasing content)', () => {
+    const tree = process('CVE-2021-34527');
+    const paragraph = tree.children[0] as Paragraph;
+    const link = paragraph.children[0] as Link;
+
+    expect(
+      link.children.every(child => 'value' in child || 'children' in child)
+    ).toBe(true);
+    // link's direct children should be text nodes (inline), not nested
+    // children-of-children objects without a `type` field
+    link.children.forEach(child => {
+      expect(child).toHaveProperty('type');
+      expect(typeof (child as { type: string }).type).toBe('string');
+    });
+  });
+
+  it('parses without error and is callable as a unified plugin', () => {
+    expect(() => parse('CVE-2021-34527')).not.toThrow();
+  });
+});

--- a/src/Markdown/plugins/remarkCve.ts
+++ b/src/Markdown/plugins/remarkCve.ts
@@ -1,24 +1,18 @@
 import { findAndReplace } from 'mdast-util-find-and-replace';
+import type { Plugin } from 'unified';
+import type { Root } from 'mdast';
 
 const CVE_REGEX = /(CVE-(19|20)\d{2}-\d{4,7})/gi;
 
-export function remarkCve() {
-  return (tree, _file) => {
-    findAndReplace(tree, [[
+export const remarkCve: Plugin<[], Root> = () => tree => {
+  findAndReplace(tree as never, [
+    [
       CVE_REGEX,
-      replaceCve as unknown as any
-    ]]);
-  };
-
-  function replaceCve(value, id) {
-    return [
-      {
+      (value: string) => ({
         type: 'link',
-        url: `https://cve.mitre.org/cgi-bin/cvename.cgi?name=${id}`,
-        children: [
-          { children: [{ type: 'text', value: value.trim() }] }
-        ]
-      }
-    ];
-  }
-}
+        url: `https://cve.mitre.org/cgi-bin/cvename.cgi?name=${value.trim()}`,
+        children: [{ type: 'text', value: value.trim() }]
+      })
+    ]
+  ]);
+};

--- a/src/Markdown/plugins/remarkCve.ts
+++ b/src/Markdown/plugins/remarkCve.ts
@@ -4,8 +4,8 @@ import type { Root } from 'mdast';
 
 const CVE_REGEX = /(CVE-(19|20)\d{2}-\d{4,7})/gi;
 
-export const remarkCve: Plugin<[], Root> = () => tree => {
-  findAndReplace(tree as never, [
+export const remarkCve: Plugin = () => tree => {
+  findAndReplace(tree as Root, [
     [
       CVE_REGEX,
       (value: string) => ({

--- a/stories/Console.stories.tsx
+++ b/stories/Console.stories.tsx
@@ -768,7 +768,7 @@ export const CVEExample = () => {
         viewType="console"
         sessions={sessionWithMarkdown}
         activeSessionId="session-cve"
-        remarkPlugins={[remarkCve as any]}
+        remarkPlugins={[remarkCve]}
       >
         <SessionsList>
           <NewSessionButton />


### PR DESCRIPTION
## Summary
- Rewrites `remarkCve` to emit a flat `link → text` mdast structure (the previous version wrapped link text in a typeless `{ children: [...] }` node, which is invalid mdast and prevented the CVE label from rendering)
- Types the plugin as `Plugin<[], Root>` and uses `value.trim()` for both the URL and label
- Adds `remarkCve.spec.ts` with 10 tests covering inline replacement, multiple/list contexts, case-insensitivity, 4–7 digit suffixes, rejection of invalid CVE-shaped strings, and AST shape

Before:
<img width="1124" height="145" alt="Screenshot 2026-05-06 at 13 18 12" src="https://github.com/user-attachments/assets/9712058c-6a19-4024-b604-a29113108f24" />

After:
<img width="1114" height="88" alt="Screenshot 2026-05-06 at 13 27 48" src="https://github.com/user-attachments/assets/6f3d3b05-3ff4-4d3b-8e24-b4f4f8e64432" />
