### PR TITLE
Adds `@default` JSDoc annotations across component prop interfaces

### DIFF
--- a/scripts/stories.cjs
+++ b/scripts/stories.cjs
@@ -10,7 +10,7 @@ const EXCLUDED_PATHS = ['./examples', './assets'];
  */
 function replacePaths() {
   // Grep all the stories
-  const files = fg.sync(['dist/stories/*.tsx', 'dist/blocks/*.tsx']);
+  const files = fg.sync(['dist/stories/*.tsx', 'dist/stories/*.ts', 'dist/blocks/*.tsx']);
 
   files.forEach((file) => {
     const code = fs.readFileSync(file, { encoding: 'utf-8' });

--- a/src/AppBar/AppBar.tsx
+++ b/src/AppBar/AppBar.tsx
@@ -10,6 +10,7 @@ export interface AppBarProps {
 
   /**
    * Custom theme for the appbar
+   * @default chatTheme
    */
   theme?: ChatTheme;
 }

--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -40,6 +40,7 @@ export interface ChatProps extends PropsWithChildren {
    * - Companion: Smaller prompt screen with session lists.
    * - Console: Full screen experience.
    * - Chat: Only chat, no sessions.
+   * @default 'console'
    */
   viewType?: ChatViewType;
 
@@ -55,11 +56,13 @@ export interface ChatProps extends PropsWithChildren {
 
   /**
    * Custom theme for the chat.
+   * @default chatTheme
    */
   theme?: ChatTheme;
 
   /**
    * Remark plugins to apply to the request/response.
+   * @default defaultRemarkPlugins
    */
   remarkPlugins?: Plugin[];
 

--- a/src/ChatInput/ChatInput.tsx
+++ b/src/ChatInput/ChatInput.tsx
@@ -31,21 +31,25 @@ export interface ChatInputProps {
 
   /**
    * Allow multiple file uploads.
+   * @default false
    */
   allowMultipleFiles?: boolean;
 
   /**
    * Placeholder text for the input field.
+   * @default 'Type a message...'
    */
   placeholder?: string;
 
   /**
    * Icon to show for send.
+   * @default <SendIcon />
    */
   sendIcon?: ReactElement;
 
   /**
    * Icon to show for stop.
+   * @default <StopIcon />
    */
   stopIcon?: ReactElement;
 
@@ -72,17 +76,20 @@ export interface ChatInputProps {
   commands?: SuggestionConfig<SlashCommandItem>;
 
   /**
-   * Minimum height for the input (default: 24px)
+   * Minimum height for the input.
+   * @default 24
    */
   minHeight?: number;
 
   /**
-   * Maximum height for the input (default: 200px)
+   * Maximum height for the input.
+   * @default 200
    */
   maxHeight?: number;
 
   /**
-   * Whether to auto-focus the input on mount (default: true)
+   * Whether to auto-focus the input on mount.
+   * @default true
    */
   autoFocus?: boolean;
 

--- a/src/ChatInput/RichTextInput.tsx
+++ b/src/ChatInput/RichTextInput.tsx
@@ -34,21 +34,25 @@ export interface RichTextInputRef {
 export interface RichTextInputProps {
   /**
    * Current value of the input
+   * @default ''
    */
   value?: string;
 
   /**
    * Placeholder text when empty
+   * @default 'Type a message...'
    */
   placeholder?: string;
 
   /**
    * Whether the input is disabled
+   * @default false
    */
   disabled?: boolean;
 
   /**
-   * Whether to auto-focus on mount (default: true)
+   * Whether to auto-focus on mount.
+   * @default true
    */
   autoFocus?: boolean;
 
@@ -58,12 +62,14 @@ export interface RichTextInputProps {
   className?: string;
 
   /**
-   * Minimum height in pixels (default: 24)
+   * Minimum height in pixels.
+   * @default 24
    */
   minHeight?: number;
 
   /**
-   * Maximum height in pixels (default: 200)
+   * Maximum height in pixels.
+   * @default 200
    */
   maxHeight?: number;
 

--- a/src/Markdown/CodeHighlighter.tsx
+++ b/src/Markdown/CodeHighlighter.tsx
@@ -35,11 +35,13 @@ export interface CodeHighlighterProps extends PropsWithChildren {
 
   /**
    * Icon to show for copy.
+   * @default <CopyIcon />
    */
   copyIcon?: ReactElement;
 
   /**
    * The theme to use for the code block.
+   * @default dark
    */
   theme?: Record<string, string>;
 }

--- a/src/Markdown/Markdown.tsx
+++ b/src/Markdown/Markdown.tsx
@@ -22,6 +22,7 @@ interface MarkdownWrapperProps extends PropsWithChildren {
 
   /**
    * Rehype plugins to apply to the markdown content.
+   * @default [rehypeRaw, rehypeKatex]
    */
   rehypePlugins?: Plugin[];
 

--- a/src/SessionMessages/SessionMessage/MessageFile/renderers/index.ts
+++ b/src/SessionMessages/SessionMessage/MessageFile/renderers/index.ts
@@ -1,4 +1,6 @@
-export * from './DefaultFileRenderer';
-export * from './CSVFileRenderer';
-export * from './ImageFileRenderer';
-export * from './PDFFileRenderer';
+// Re-export the default-exported renderers as named exports so they are
+// reachable from the package root (for docs/TSDoc and external consumers).
+export { default as DefaultFileRenderer } from './DefaultFileRenderer';
+export { default as CSVFileRenderer } from './CSVFileRenderer';
+export { default as ImageFileRenderer } from './ImageFileRenderer';
+export { default as PDFFileRenderer } from './PDFFileRenderer';

--- a/src/SessionMessages/SessionMessagePanel.tsx
+++ b/src/SessionMessages/SessionMessagePanel.tsx
@@ -5,6 +5,10 @@ import { motion } from 'motion/react';
 import BackIcon from '@/assets/back.svg?react';
 
 interface SessionMessagePanelProps extends PropsWithChildren {
+  /**
+   * Whether to show the back button to return to the session list in compact mode.
+   * @default true
+   */
   allowBack?: boolean;
 }
 

--- a/src/SessionMessages/SessionMessages.tsx
+++ b/src/SessionMessages/SessionMessages.tsx
@@ -34,16 +34,19 @@ interface SessionMessagesProps {
 
   /**
    * Limit the number of results returned. Clientside pagination.
+   * @default 10
    */
   limit?: number | null;
 
   /**
    * Text to display for the show more button.
+   * @default 'Show more'
    */
   showMoreText?: string;
 
   /**
    * Whether to automatically scroll to the bottom of the content.
+   * @default true
    */
   autoScroll?: boolean;
 
@@ -59,6 +62,7 @@ interface SessionMessagesProps {
 
   /**
    * Whether to show the load more button.
+   * @default false
    */
   showLoadMoreButton?: boolean;
 

--- a/src/SessionsList/NewSessionButton.tsx
+++ b/src/SessionsList/NewSessionButton.tsx
@@ -8,6 +8,7 @@ import PlusIcon from '@/assets/plus.svg?react';
 interface NewSessionButtonProps extends PropsWithChildren {
   /**
    * Text for the new session button.
+   * @default 'New Session'
    */
   newSessionText?: string | ReactNode;
 }

--- a/src/SessionsList/SessionListItem.tsx
+++ b/src/SessionsList/SessionListItem.tsx
@@ -21,21 +21,25 @@ export interface SessionListItemProps extends PropsWithChildren {
 
   /**
    * Indicates whether the session is deletable.
+   * @default true
    */
   deletable?: boolean;
 
   /**
    * Icon to show for delete.
+   * @default <TrashIcon />
    */
   deleteIcon?: ReactElement;
 
   /**
    * Icon to show for chat.
+   * @default <ChatIcon className="mr-2" />
    */
   chatIcon?: ReactElement;
 
   /**
    * Limit for the ellipsis.
+   * @default 100
    */
   limit?: number;
 }

--- a/stories/ChatSuggestions.stories.tsx
+++ b/stories/ChatSuggestions.stories.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Meta } from '@storybook/react';
+import type { Meta } from '@storybook/react';
 import {
   Chat,
   SessionsList,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
## Changes

### Prop documentation (`@default` annotations)
Added standard `@default` JSDoc tags to public prop interfaces so default values surface in TSDoc/IDE tooltips. Verified accurate against implementation defaults:

| Component | Annotated props |
|-----------|-----------------|
| `Chat` | `viewType` (`'console'`), `theme`, `remarkPlugins` |
| `ChatInput` | `allowMultipleFiles`, `placeholder`, `sendIcon`, `stopIcon`, `minHeight`, `maxHeight`, `autoFocus` |
| `RichTextInput` | `value`, `placeholder`, `disabled`, `autoFocus`, `minHeight`, `maxHeight` |
| `SessionMessages` | `limit`, `showMoreText`, `autoScroll`, `showLoadMoreButton` |
| `SessionListItem` | `deletable`, `deleteIcon`, `chatIcon`, `limit` |
| `SessionMessagePanel` | `allowBack` |
| `NewSessionButton` | `newSessionText` |
| `AppBar` | `theme` |
| `CodeHighlighter` | `copyIcon`, `theme` |
| `Markdown` | `rehypePlugins` |

Pre-existing inline `(default: ...)` notes were migrated to the consistent `@default` format.

### Export fix
- `MessageFile/renderers/index.ts` — switched from `export *` (which does **not** re-export default exports) to explicit `export { default as ... }`, making `DefaultFileRenderer`, `CSVFileRenderer`, `ImageFileRenderer`, and `PDFFileRenderer` reachable from the package root.

### Build / tooling
- `scripts/stories.cjs` — include `dist/stories/*.ts` in the story path glob.
- `stories/ChatSuggestions.stories.tsx` — use `import type { Meta }` for the type-only import.
